### PR TITLE
Code Climate Ignore

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,44 @@
+version: 2
+jobs:
+  build:
+    environment:
+      CC_TEST_REPORTER_ID: 1575b266c8da9a3ef59e4e67d55a4a373ebec0f26f87fed6540816d0a66508ec
+    docker:
+      - image: circleci/node:carbon
+
+    working_directory: ~/repo
+
+    steps:
+      - checkout
+
+      - restore_cache:
+          keys:
+            - v1-dependencies-{{ checksum "package.json" }}
+            - v1-dependencies-
+
+      - run: npm install
+
+      - run:
+          name: Setup Code Climate test-reporter
+          command: |
+            curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+            chmod +x ./cc-test-reporter
+
+      - save_cache:
+          paths:
+            - node_modules
+          key: v1-dependencies-{{ checksum "package.json" }}
+
+      # Build the app
+      - run:
+          name: Build the app
+          command:
+            npm run build
+
+      # run tests and post coverage to cc
+      - run:
+          name: Run tests
+          command: |
+            ./cc-test-reporter before-build
+            npm test
+            ./cc-test-reporter after-build --exit-code $?

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,2 @@
+exclude_patterns:
+  - '**/__test__/'

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
 # Slack Block Message Kit
 
+[![Maintainability](https://api.codeclimate.com/v1/badges/e9a5b2d6a3e658892de3/maintainability)](https://codeclimate.com/github/IyiKuyoro/slack-block-msg-kit/maintainability) [![Test Coverage](https://api.codeclimate.com/v1/badges/e9a5b2d6a3e658892de3/test_coverage)](https://codeclimate.com/github/IyiKuyoro/slack-block-msg-kit/test_coverage) [![npm version](https://badge.fury.io/js/slack-block-msg-kit.svg)](https://badge.fury.io/js/slack-block-msg-kit)
+
 This is a simple package that helps build slack block messages and all it's elements. It has robust validations to ensure mistakes are not made with the message formating.
+**Still in development**


### PR DESCRIPTION
# Code Climate Ignore

## What does this PR do

This PR adds the test files to the ignore pater of code climate

## Background context

Tests files are not a necessary part of what we wish to evaluate for maintainability.

## Task completed (detailed list of changes/additions)

- [x] Add the test files to be ignored
