### PR TITLE
Add Static Select Class

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,16 @@ This is a simple library that helps build slack block messages and all it's elem
         - [Adding a URL to the button](#Adding-a-URL-to-the-button)
         - [Adding a value](#Adding-a-value)
         - [Changing the style of the button](#Changing-the-style-of-the-button)
-        - [Adding a confirmation dialog](#Adding-a-confirmation-dialog)
+        - [Adding a confirmation dialog (Button)](#Adding-a-confirmation-dialog-Button)
       - [Image Element](#Image-Element)
         - [Importing the image class](#Importing-the-image-class)
         - [Creating an Image Element](#Creating-an-Image-Element)
+      - [Static Select](#Static-Select)
+        - [Importing the StaticSelect Class](#Importing-the-StaticSelect-Class)
+        - [Creating a Static Select Object](#Creating-a-Static-Select-Object)
+        - [Adding options (StaticSelect)](#Adding-options-StaticSelect)
+        - [Adding a confirmation dialog (StaticSelectElement)](#Adding-a-confirmation-dialog-StaticSelectElement)
+        - [Possible Errors (StaticSelect)](#Possible-Errors-StaticSelect)
     - [Composition Objects](#Composition-Objects)
       - [Text](#Text)
         - [Importing the Text Class](#Importing-the-Text-Class)
@@ -535,7 +541,7 @@ const button = new ButtonElement('Close', 'ACT001');
 button.changeStyle(ButtonStyle.danger);
 ```
 
-##### Adding a confirmation dialog
+##### Adding a confirmation dialog (Button)
 
 You may wish to confirm the user action before executing with a [Confirmation Dialog](#Confirmation-Dialog). Simply make use of the (**addConfirmationDialogByParameters**) method for this.
 
@@ -580,6 +586,121 @@ import { ImageElement } from 'slack-block-msg-kit';
 
 const img = new ImageElement('https://fakeimage.img', 'fake image');
 ```
+
+#### Static Select
+
+Static select renders a select menu from a static list of options.
+
+##### Importing the StaticSelect Class
+
+```javascript
+import { StaticSelectElement } from 'slack-block-msg-kit';
+```
+
+or
+
+```javascript
+import StaticSelectElement from 'slack-block-msg-kit/BlockElements/StaticSelectElement';
+```
+
+##### Creating a Static Select Object
+
+| Parameter | Type | Description | Example |
+| --------- | ---- | ----------- | ------- |
+| actionId  | string | The action id of the select element | 'ACT001' |
+| placeholder | string | The placeholder text for the select element | 'select an option' |
+
+Creating a static select object is done by passing the two required parameters to the constructor. The constructed select object cannot be used right away. some options need to be added to it.
+
+```javascript
+import StaticSelectElement from 'slack-block-msg-kit/BlockElements/StaticSelectElement';
+
+const sse = new StaticSelectElement('actionId', 'placeholder');
+```
+
+##### Adding options (StaticSelect)
+
+There are two ways of adding options to a static select object.
+
+- Adding an [options](#Option) array (**addOptions**)
+- Adding an [optionGroups](#OptionGroup) array (**addOptionGroups**)
+
+One StaticSelect object cannot have both options and option groups.
+
+**addOptions**: To add options to the StaticSelectObject, all that is required is to call the addOptions method.
+
+| Parameter | Type | Description | Example |
+| --------- | ---- | ----------- | ------- |
+| options   | [Option](#Option)[] | An array of options to be added to the menu | [ new Option('Option 1', 'one') ] |
+| _initialOptionIndex_ | number? | The index of the option to be used as the selected option when the menu is loaded | 0 |
+
+Below is an example
+
+```javascript
+import StaticSelectElement from 'slack-block-msg-kit/BlockElements/StaticSelectElement';
+import Option from 'slack-block-msg-kit/CompositionObjects/Option';
+
+const sse = new StaticSelectElement('actionId', 'placeholder');
+
+sse.addOptions([
+  new Option('Option 1', 'one'),
+]);
+```
+
+**addOptionGroup**: To add option groups to the StaticSelect element, all that is required is to call the addOptionGroup method.
+
+| Parameter | Type | Description | Example |
+| --------- | ---- | ----------- | ------- |
+| optionGroups   | [OptionGroup](#OptionGroup)[] | An array of option groups to be added to the menu | [ new OptionGroup('Group', [new Option('Option 1', 'one')])] |
+| _initialOptionGroupIndex_ | number? | The index of the option group to be used in selecting options array which contains the option to be used as the selected option when the menu is loaded | 0 |
+| _initialOptionIndex_ | number? | The index of the option to be used as the selected option when the menu is loaded | 0 |
+
+Below is an example
+
+```javascript
+import StaticSelectElement from 'slack-block-msg-kit/BlockElements/StaticSelectElement';
+import Option from 'slack-block-msg-kit/CompositionObjects/Option';
+import OptionGroup from 'slack-block-msg-kit/CompositionObjects/OptionGroup';
+
+const sse = new StaticSelectElement('actionId', 'placeholder');
+
+sse.addOptionGroups(
+  [ new OptionGroup('Group', [new Option('Option 1', 'one')])],
+);
+```
+
+##### Adding a confirmation dialog (StaticSelectElement)
+
+You may wish to confirm the user selection with a [Confirmation Dialog](#Confirmation-Dialog). Simply make use of the (**addConfirmationDialogByParameters**) method for this.
+
+```javascript
+import StaticSelectElement from 'slack-block-msg-kit/BlockElements/StaticSelectElement';
+import Option from 'slack-block-msg-kit/CompositionObjects/Option';
+import Text, { TextType } from 'slack-block-msg-kit/CompositionObjects/Text';
+
+const sse = new StaticSelectElement('actionId', 'placeholder');
+
+sse.addOptionGroups([
+  new Option('Option 1', 'one'),
+]).addConfirmationDialogByParameters(
+  'confirm',
+  new Text(TextType.plainText, 'Are you sure?'),
+  'Yes',
+  'No',
+);
+```
+
+##### Possible Errors (StaticSelect)
+
+| Error | Cause | Remedy |
+| ----- | ----- | ------ |
+| 'placeholder should not be more than 150 characters.' | Adding more than 150 characters in the placeholder | Reduce the placeholder size |
+| 'actionId should not be more than 255 characters.' | Adding more than 255 characters in the actionId | Reduce the actionId size |
+| 'StaticSelectElement cannot have both options and option_groups' | Adding options and optionGroups to the same StaticSelect element | Use on of the two |
+| 'Cannot have more than 100 options' | Adding more than 100 options in the options array | Max options array size should be 100 |
+| 'Cannot have more than 100 optionGroups' | Adding more than 100 options in the optionGroups array | Max optionGroups array size should be 100 |
+| 'initialOptionGroupIndex is out of optionGroup range' | Selecting an optionGroupIndex that is beyond the optionGroups array ranch | Use an initialOptionGroupIndex in the optionGroups array range|
+| 'initialOptionIndex is out of options range' | selecting an initialOptionIndex that is beyond the options array range | Use an initialOptionIndex that is in the option array range |
 
 ### Composition Objects
 

--- a/README.md
+++ b/README.md
@@ -60,10 +60,14 @@ This is a simple library that helps build slack block messages and all it's elem
         - [Importing a Confirmation Dialog](#Importing-a-Confirmation-Dialog)
         - [Creating a Confirmation Dialog](#Creating-a-Confirmation-Dialog)
       - [Option](#Option)
-        - [Importing the Option class](#Importing-the-Option-class)
+        - [Importing the Option Class](#Importing-the-Option-Class)
         - [Creating an Option](#Creating-an-Option)
         - [Adding a url (Option.addUrl)](#Adding-a-url-OptionaddUrl)
         - [Possible Errors (Option)](#Possible-Errors-Option)
+      - [OptionGroup](#OptionGroup)
+        - [Importing the OptionGroup Class](#Importing-the-OptionGroup-Class)
+        - [Creating an OptionGroup](#Creating-an-OptionGroup)
+        - [Possible Errors (OptionGroup)](#Possible-Errors-OptionGroup)
 
 ## Currently available classes
 
@@ -85,6 +89,8 @@ This library is still in active development and only the following classes are c
 
 > - **Text** > <https://api.slack.com/reference/messaging/composition-objects#text>
 > - **Confirmation Dialog** > <https://api.slack.com/reference/messaging/composition-objects#confirm>
+> - **Option** > <https://api.slack.com/reference/messaging/composition-objects#option>
+> - **OptionGroup** > <https://api.slack.com/reference/messaging/composition-objects#option-group>
 
 ## How to Use
 
@@ -722,7 +728,7 @@ const dialog = new ConfirmationDialog(
 
 An option is a selection from a list. It is usually used with select elements for drop down menus.
 
-##### Importing the Option class
+##### Importing the Option Class
 
 ```javascript
 import { Option } from 'slack-block-msg-kit';
@@ -768,4 +774,49 @@ opt.addUrl('https://fakeurl.com');
 
 | Error | Cause | Remedy |
 | ----- | ----- | ------ |
+| 'text cannot be more than 75 characters' | Adding more than 75 characters in the text | Reduce the text size |
+| 'value cannot be more than 75 characters' | Adding more than 75 characters in the value | Reduce the value size |
 | 'url cannot be more than 3000 characters' | Adding a url that is more than 3000 characters | Reduce the url length with a tool like <https://bitly.com/> |
+
+#### OptionGroup
+
+An option group is a way of collection options together in a select menu.
+
+##### Importing the OptionGroup Class
+
+```javascript
+import { OptionGroup } from 'slack-block-msg-kit';
+```
+
+or
+
+```javascript
+import OptionGroup from 'slack-block-msg-kit/CompositionObjects/OptionGroup';
+```
+
+##### Creating an OptionGroup
+
+| Parameter | Type | Description | Example |
+| --------- | ---- | ----------- | ------- |
+| label     | string | The babel of this option group | 'Group one' |
+| options   | [Option](#Option)[] | An array of options to be added to the group. | [ new Option('option 1', 'one') ] |
+
+Creating an option group object is as simple as calling the constructor and passing the required parameters.
+
+```javascript
+import Option from 'slack-block-msg-kit/CompositionObjects/Option';
+import OptionGroup from 'slack-block-msg-kit/CompositionObjects/OptionGroup';
+
+const opts = new OptionGroup(
+  'options',
+  [new Option('option', 'option')]
+);
+```
+
+##### Possible Errors (OptionGroup)
+
+| Error | Cause | Remedy |
+| ----- | ----- | ------ |
+| 'label cannot be more than 75 characters' | Adding more than 75 characters in the label | Reduce the label size |
+| 'Cannot have more than 100 options in a group' | Adding more than 100 options in one group | Reduce the number of options in the array. |
+| 'Two options cannot share the same value in one group: 'value'' | Having two options with the same value in one group | Use unique values for each option. |

--- a/README.md
+++ b/README.md
@@ -59,6 +59,11 @@ This is a simple library that helps build slack block messages and all it's elem
       - [Confirmation Dialog](#Confirmation-Dialog)
         - [Importing a Confirmation Dialog](#Importing-a-Confirmation-Dialog)
         - [Creating a Confirmation Dialog](#Creating-a-Confirmation-Dialog)
+      - [Option](#Option)
+        - [Importing the Option class](#Importing-the-Option-class)
+        - [Creating an Option](#Creating-an-Option)
+        - [Adding a url (Option.addUrl)](#Adding-a-url-OptionaddUrl)
+        - [Possible Errors (Option)](#Possible-Errors-Option)
 
 ## Currently available classes
 
@@ -712,3 +717,55 @@ const dialog = new ConfirmationDialog(
   'No, I change my mind.',
 );
 ```
+
+#### Option
+
+An option is a selection from a list. It is usually used with select elements for drop down menus.
+
+##### Importing the Option class
+
+```javascript
+import { Option } from 'slack-block-msg-kit';
+```
+
+or
+
+```javascript
+import Option from 'slack-block-msg-kit/CompositionObjects/Option';
+```
+
+##### Creating an Option
+
+| Parameter | Type | Description | Example |
+| --------- | ---- | ----------- | ------- |
+| text      | string | The text rendered as a plain text as the option's label on slack | 'Option 1' |
+| value     | string | The value returned to your application as part of the payload when this option is selected | 'one' |
+
+Create an option by passing the two required parameters to the constructor. Both parameters are strings that cannot be more than 75 characters long.
+
+```javascript
+import Option from 'slack-block-msg-kit/CompositionObjects/Option';
+
+const opt = new Option('Option 1', 'one');
+```
+
+##### Adding a url (Option.addUrl)
+
+| Parameter | Type | Description | Example |
+| --------- | ---- | ----------- | ------- |
+| url       | string | The url to be loaded in the user's browser | '<https://fakeurl.com>' |
+
+A url that can be loaded in the user's browser is one of the optional properties that can be added to the Option object. To add a url, simply call the **addUrl** method. The url passed cannot be more than 3000 characters.
+
+```javascript
+import Option from 'slack-block-msg-kit/CompositionObjects/Option';
+
+const opt = new Option('Option 1', 'one');
+opt.addUrl('https://fakeurl.com');
+```
+
+##### Possible Errors (Option)
+
+| Error | Cause | Remedy |
+| ----- | ----- | ------ |
+| 'url cannot be more than 3000 characters' | Adding a url that is more than 3000 characters | Reduce the url length with a tool like <https://bitly.com/> |

--- a/src/BlockElements/BlockElement.ts
+++ b/src/BlockElements/BlockElement.ts
@@ -21,7 +21,7 @@ export default abstract class BlockElement {
   public type: BlockElementType;
 
   /**
-   * @description Constructs a new block element
+   * @description Constructs a new block element.
    * @param  {BlockElementType} type The type of the block element being created
    */
   constructor(type: BlockElementType, actionId?: string) {

--- a/src/BlockElements/ButtonElement.ts
+++ b/src/BlockElements/ButtonElement.ts
@@ -72,7 +72,7 @@ export default class ButtonElement extends BlockElement {
 
   /**
    * @description Add a confirmation dialog by providing the parameters that is displayed when the button is clicked.
-   * This method will create the confirmation dialog. If you want full control over how the dialog is created we suggest (addConfirmationDialog).
+   * This method will create the confirmation dialog.
    * @param  {string} dialogTitle The message to be displayed in the dialog
    * @param  {Text} dialogText The message to be displayed in the dialog
    * @param  {string} confirmButton The confirm button label text

--- a/src/BlockElements/SelectElement.ts
+++ b/src/BlockElements/SelectElement.ts
@@ -1,0 +1,25 @@
+import Text, { TextType } from '../CompositionObjects/Text';
+import { Helpers } from '../helpers';
+import BlockElement, { BlockElementType } from './BlockElement';
+
+/**
+ * @description This is the base class for other select elements like static select. You cannot create an instance of this class.
+ * For more info regarding select elements, kindly visit https://api.slack.com/reference/messaging/block-elements#select
+ */
+export default abstract class SelectElement extends BlockElement {
+  public placeholder: Text;
+
+  /**
+   * @description Create a new instance of a select element.
+   * @param  {string} elementType The select element type
+   * @param  {string} actionId The action id for the select element
+   * @param  {string} placeholder The select element placeholder
+   */
+  constructor(elementType: BlockElementType, actionId: string, placeholder: string) {
+    super(elementType, actionId);
+
+    Helpers.validateString(placeholder, 'placeholder', 150);
+
+    this.placeholder = new Text(TextType.plainText, placeholder);
+  }
+}

--- a/src/BlockElements/StaticSelectElement.ts
+++ b/src/BlockElements/StaticSelectElement.ts
@@ -1,0 +1,126 @@
+import ConfirmationDialog from '../CompositionObjects/ConfirmationDialog';
+import Option from '../CompositionObjects/Option';
+import OptionGroup from '../CompositionObjects/OptionGroup';
+import Text from '../CompositionObjects/Text';
+import { Helpers } from '../helpers';
+import { BlockElementType } from './BlockElement';
+import SelectElement from './SelectElement';
+
+/**
+ * @description This is the static select element class.
+ * For more info regarding static select elements, kindly visit https://api.slack.com/reference/messaging/block-elements#static-select
+ */
+export default class StaticSelectElement extends SelectElement {
+  public options?: Option[];
+  public option_groups?: OptionGroup[];
+  public initial_option?: Option;
+  public confirm?: ConfirmationDialog;
+
+  /**
+   * @description Create an instance of the static select element
+   * @param  {string} actionId The action id for the select element.
+   * @param  {string} placeholder The select element placeholder
+   */
+  constructor(actionId: string, placeholder: string) {
+    super(BlockElementType.selectStatic, actionId, placeholder);
+  }
+
+  /**
+   * @description Add options to the select menu
+   * @param  {Option[]} options An array of options
+   * @param  {number} initialOptionIndex? The index of the option to be selected from the group
+   * @returns StaticSelectElement
+   */
+  public addOptions(options: Option[], initialOptionIndex?: number): StaticSelectElement {
+    if (this.option_groups) {
+      throw new Error('StaticSelectElement cannot have both options and option_groups');
+    }
+
+    Helpers.validateArrayLength(options, 100, 'Cannot have more than 100 options');
+    Helpers.validateOptions(options);
+
+    this.options = options;
+    this.assignInitialOptionOptions(options, initialOptionIndex);
+
+    return this;
+  }
+
+  /**
+   * @description Add options groups to this select element
+   * @param  {OptionGroup[]} optionGroups An array of option groups
+   * @param  {number} initialOptionGroupIndex? The index of the option group to select the option from
+   * @param  {number} initialOptionIndex? The index of the option to be selected from the group
+   * @returns StaticSelectElement
+   */
+  public addOptionGroups(
+    optionGroups: OptionGroup[],
+    initialOptionGroupIndex?: number,
+    initialOptionIndex?: number,
+  ): StaticSelectElement {
+    if (this.options) {
+      throw new Error('StaticSelectElement cannot have both options and option_groups');
+    }
+
+    Helpers.validateArrayLength(optionGroups, 100, 'Cannot have more than 100 optionGroups');
+
+    this.option_groups = optionGroups;
+    this.assignInitialOptionOptionGroups(optionGroups, initialOptionGroupIndex, initialOptionIndex);
+
+    return this;
+  }
+
+  /**
+   * @description Add a confirmation dialog by providing the parameters that is displayed when an option is selected.
+   * This method will create the confirmation dialog.
+   * @param  {string} dialogTitle The dialog title
+   * @param  {Text} dialogText The message to be displayed in the dialog
+   * @param  {string} confirmButton The confirm button label text
+   * @param  {string} denyButton The deny button text
+   * @returns ButtonElement
+   */
+  public addConfirmationDialogByParameters(
+    dialogTitle: string,
+    dialogText: Text,
+    confirmButton: string,
+    denyButton: string,
+  ): StaticSelectElement {
+    this.confirm = new ConfirmationDialog(dialogTitle, dialogText, confirmButton, denyButton);
+
+    return this;
+  }
+
+  /**
+   * @description Assigns the initial option property for option group
+   * @param  {OptionGroup[]} optionGroups The array of option groups
+   * @param  {number} initialOptionGroupIndex? The index of the option group to select the option from
+   * @param  {number} initialOptionIndex? The index of the option to be selected from the group
+   */
+  private assignInitialOptionOptionGroups(
+    optionGroups: OptionGroup[],
+    initialOptionGroupIndex?: number,
+    initialOptionIndex?: number,
+  ): void {
+    if (initialOptionGroupIndex !== undefined && initialOptionIndex !== undefined) {
+      if (optionGroups[initialOptionGroupIndex] && optionGroups[initialOptionGroupIndex].options[initialOptionIndex]) {
+        this.initial_option = optionGroups[initialOptionGroupIndex].options[initialOptionIndex];
+      } else if (!optionGroups[initialOptionGroupIndex]) {
+        throw new Error('initialOptionGroupIndex is out of optionGroup range');
+      } else {
+        throw new Error('initialOptionIndex is out of options range');
+      }
+    }
+  }
+
+  /**
+   * @description Assign initial option for options
+   * @param  {Option[]} options The array of options
+   * @param  {number} initialOptionIndex? The option index
+   */
+  private assignInitialOptionOptions(options: Option[], initialOptionIndex?: number) {
+    if (initialOptionIndex !== undefined && options[initialOptionIndex]) {
+      this.initial_option = options[initialOptionIndex];
+    } else if (initialOptionIndex !== undefined && !options[initialOptionIndex]) {
+      throw new Error('initialOptionIndex must be a positive integer less than the options length');
+    }
+  }
+}

--- a/src/BlockElements/__tests__/SelectStaticElements.spec.ts
+++ b/src/BlockElements/__tests__/SelectStaticElements.spec.ts
@@ -1,0 +1,205 @@
+import Option from '../../CompositionObjects/Option';
+import OptionGroup from '../../CompositionObjects/OptionGroup';
+import Text, { TextType } from '../../CompositionObjects/Text';
+import StaticSelectElement from '../StaticSelectElement';
+
+describe('StaticSelectElement', () => {
+  it('should create a static select element', () => {
+    const staticSelect = new StaticSelectElement('ACT001', 'Select placeholder');
+
+    expect(staticSelect).toEqual({
+      action_id: 'ACT001',
+      placeholder: {
+        text: 'Select placeholder',
+        type: 'plain_text',
+      },
+      type: 'static_select',
+    });
+  });
+
+  describe('addOptions', () => {
+    it('should throw an error if option_group has already been assigned', done => {
+      try {
+        const staticSelect = new StaticSelectElement('ACT001', 'Select placeholder');
+        const optGroup = new OptionGroup('Group', [new Option('Option 1', 'one')]);
+        staticSelect.addOptionGroups([optGroup]);
+
+        staticSelect.addOptions([new Option('Option 2', 'two')]);
+      } catch (error) {
+        expect(error.message).toEqual('StaticSelectElement cannot have both options and option_groups');
+        done();
+      }
+    });
+
+    it('should add options without the initial option', () => {
+      const staticSelect = new StaticSelectElement('ACT001', 'Select placeholder');
+
+      staticSelect.addOptions([new Option('Option 1', 'one')]);
+
+      expect(staticSelect.options).toEqual([
+        {
+          text: {
+            text: 'Option 1',
+            type: 'plain_text',
+          },
+          value: 'one',
+        },
+      ]);
+    });
+
+    it('should add options with the initial option', () => {
+      const staticSelect = new StaticSelectElement('ACT001', 'Select placeholder');
+
+      staticSelect.addOptions([new Option('Option 1', 'one')], 0);
+
+      expect(staticSelect.initial_option).toEqual({
+        text: {
+          text: 'Option 1',
+          type: 'plain_text',
+        },
+        value: 'one',
+      });
+    });
+
+    it('should throw an error if initial option index is out of array bound', done => {
+      try {
+        const staticSelect = new StaticSelectElement('ACT001', 'Select placeholder');
+
+        staticSelect.addOptions([new Option('Option 1', 'one')], 1);
+      } catch (error) {
+        expect(error.message).toEqual('initialOptionIndex must be a positive integer less than the options length');
+
+        done();
+      }
+    });
+
+    it('should throw an error if initial option index is less than zero', done => {
+      try {
+        const staticSelect = new StaticSelectElement('ACT001', 'Select placeholder');
+
+        staticSelect.addOptions([new Option('Option 1', 'one')], -1);
+      } catch (error) {
+        expect(error.message).toEqual('initialOptionIndex must be a positive integer less than the options length');
+
+        done();
+      }
+    });
+  });
+
+  describe('addOptionGroups', () => {
+    it('should throw error if options has already been assigned', done => {
+      try {
+        const staticSelect = new StaticSelectElement('ACT001', 'Select placeholder');
+        staticSelect.addOptions([new Option('Option 2', 'two')]);
+
+        const optGroup = new OptionGroup('Group', [new Option('Option 1', 'one')]);
+
+        staticSelect.addOptionGroups([optGroup]);
+      } catch (error) {
+        expect(error.message).toEqual('StaticSelectElement cannot have both options and option_groups');
+        done();
+      }
+    });
+
+    it('should add option group without the initial option', () => {
+      const staticSelect = new StaticSelectElement('ACT001', 'Select placeholder');
+
+      const optGroup = new OptionGroup('Group', [new Option('Option 1', 'one')]);
+
+      staticSelect.addOptionGroups([optGroup]);
+
+      expect(staticSelect.option_groups).toEqual([
+        {
+          label: {
+            text: 'Group',
+            type: 'plain_text',
+          },
+          options: [
+            {
+              text: {
+                text: 'Option 1',
+                type: 'plain_text',
+              },
+              value: 'one',
+            },
+          ],
+        },
+      ]);
+    });
+
+    it('should add option group with the initial option', () => {
+      const staticSelect = new StaticSelectElement('ACT001', 'Select placeholder');
+
+      const optGroup = new OptionGroup('Group', [new Option('Option 1', 'one')]);
+
+      staticSelect.addOptionGroups([optGroup], 0, 0);
+
+      expect(staticSelect.initial_option).toEqual({
+        text: {
+          text: 'Option 1',
+          type: 'plain_text',
+        },
+        value: 'one',
+      });
+    });
+
+    it('should throw an error if a wrong initialOptionGroupIndex are passed', done => {
+      try {
+        const staticSelect = new StaticSelectElement('ACT001', 'Select placeholder');
+
+        const optGroup = new OptionGroup('Group', [new Option('Option 1', 'one')]);
+
+        staticSelect.addOptionGroups([optGroup], 1, 0);
+      } catch (error) {
+        expect(error.message).toEqual('initialOptionGroupIndex is out of optionGroup range');
+        done();
+      }
+    });
+
+    it('should throw an error if a wrong initialOptionIndex are passed', done => {
+      try {
+        const staticSelect = new StaticSelectElement('ACT001', 'Select placeholder');
+
+        const optGroup = new OptionGroup('Group', [new Option('Option 1', 'one')]);
+
+        staticSelect.addOptionGroups([optGroup], 0, 1);
+      } catch (error) {
+        expect(error.message).toEqual('initialOptionIndex is out of options range');
+        done();
+      }
+    });
+  });
+
+  describe('addConfirmationDialogByParameters', () => {
+    it('should add confirmation dialog', () => {
+      const staticSelect = new StaticSelectElement('ACT001', 'Select placeholder');
+      staticSelect.addOptions([new Option('Option 1', 'one')]);
+
+      staticSelect.addConfirmationDialogByParameters(
+        'Confirm',
+        new Text(TextType.plainText, 'dialog text'),
+        'Yes',
+        'No',
+      );
+
+      expect(staticSelect.confirm).toEqual({
+        confirm: {
+          text: 'Yes',
+          type: 'plain_text',
+        },
+        deny: {
+          text: 'No',
+          type: 'plain_text',
+        },
+        text: {
+          text: 'dialog text',
+          type: 'plain_text',
+        },
+        title: {
+          text: 'Confirm',
+          type: 'plain_text',
+        },
+      });
+    });
+  });
+});

--- a/src/CompositionObjects/Option.ts
+++ b/src/CompositionObjects/Option.ts
@@ -1,0 +1,36 @@
+import { Helpers } from '../helpers';
+import Text, { TextType } from './Text';
+
+/** This class represents a Slack Option.
+ *  For more info kindly visit https://api.slack.com/reference/messaging/composition-objects#option
+ */
+export default class Option {
+  public text: Text;
+  public value: string;
+  public url?: string;
+
+  /**
+   * @description Create a new instance of the option class
+   * @param  {string} text The text to be used in creating the Text object
+   * @param  {string} value The value to be returned to your application when this option is selected
+   */
+  constructor(text: string, value: string) {
+    Helpers.validateString(text, 'text', 75);
+    Helpers.validateString(value, 'value', 75);
+
+    this.text = new Text(TextType.plainText, text);
+    this.value = value;
+  }
+
+  /**
+   * @description Add url parameter to the Option
+   * @param  {string} url URL to be loaded in the browser when this option is selected
+   * @returns Option
+   */
+  public addUrl(url: string): Option {
+    Helpers.validateString(url, 'url', 3000);
+
+    this.url = url;
+    return this;
+  }
+}

--- a/src/CompositionObjects/OptionGroup.ts
+++ b/src/CompositionObjects/OptionGroup.ts
@@ -1,0 +1,47 @@
+import { Helpers } from '../helpers';
+import Option from './Option';
+import Text, { TextType } from './Text';
+
+/** This class represents a Slack Option.
+ *  For more info kindly visit https://api.slack.com/reference/messaging/composition-objects#option-group
+ */
+export default class OptionGroup {
+  public label: Text;
+  public options: Option[];
+
+  /**
+   * @description Create an option group
+   * @param  {string} label The label displayed above the group of options
+   * @param  {Option[]} options An array of options to be displayed
+   */
+  constructor(label: string, options: Option[]) {
+    Helpers.validateString(label, 'label', 75);
+
+    if (options.length > 100) {
+      throw new Error('Cannot have more than 100 options in a group');
+    }
+    this.validateOptions(options);
+
+    this.label = new Text(TextType.plainText, label);
+    this.options = options;
+  }
+
+  /**
+   * @description Ensure thant no two options have the same value
+   * @param  {Option[]} options
+   * @returns void
+   */
+  private validateOptions(options: Option[]): void {
+    const optionsValues: { [k: string]: boolean } = {};
+
+    for (const option of options) {
+      const value = option.value;
+
+      if (optionsValues[value]) {
+        throw new Error(`Two options cannot share the same value in one group: '${value}'`);
+      }
+
+      optionsValues[value] = true;
+    }
+  }
+}

--- a/src/CompositionObjects/OptionGroup.ts
+++ b/src/CompositionObjects/OptionGroup.ts
@@ -16,32 +16,10 @@ export default class OptionGroup {
    */
   constructor(label: string, options: Option[]) {
     Helpers.validateString(label, 'label', 75);
-
-    if (options.length > 100) {
-      throw new Error('Cannot have more than 100 options in a group');
-    }
-    this.validateOptions(options);
+    Helpers.validateArrayLength(options, 100, 'Cannot have more than 100 options in a group');
+    Helpers.validateOptions(options);
 
     this.label = new Text(TextType.plainText, label);
     this.options = options;
-  }
-
-  /**
-   * @description Ensure thant no two options have the same value
-   * @param  {Option[]} options
-   * @returns void
-   */
-  private validateOptions(options: Option[]): void {
-    const optionsValues: { [k: string]: boolean } = {};
-
-    for (const option of options) {
-      const value = option.value;
-
-      if (optionsValues[value]) {
-        throw new Error(`Two options cannot share the same value in one group: '${value}'`);
-      }
-
-      optionsValues[value] = true;
-    }
   }
 }

--- a/src/CompositionObjects/__tests__/Option.spec.ts
+++ b/src/CompositionObjects/__tests__/Option.spec.ts
@@ -1,0 +1,32 @@
+import Option from '../Option';
+
+describe('Option', () => {
+  it('should create an option object', () => {
+    const opt = new Option('Option 1', '1');
+
+    expect(opt).toEqual({
+      text: {
+        text: 'Option 1',
+        type: 'plain_text',
+      },
+      value: '1',
+    });
+  });
+
+  describe('addUrl()', () => {
+    it('should add a url to the option', () => {
+      const opt = new Option('Option 1', '1');
+
+      opt.addUrl('https://fakeurl.com');
+
+      expect(opt).toEqual({
+        text: {
+          text: 'Option 1',
+          type: 'plain_text',
+        },
+        url: 'https://fakeurl.com',
+        value: '1',
+      });
+    });
+  });
+});

--- a/src/CompositionObjects/__tests__/OptionGroup.spec.ts
+++ b/src/CompositionObjects/__tests__/OptionGroup.spec.ts
@@ -1,0 +1,48 @@
+import Option from '../Option';
+import OptionGroup from '../OptionGroup';
+
+describe('OptionGroup', () => {
+  it('should throw an error if more than 100 options are passed', done => {
+    try {
+      const options = [];
+
+      for (let i = 0; i < 101; i++) {
+        options.push(new Option(`Option ${i}`, `${i}`));
+      }
+
+      const og = new OptionGroup('options', options);
+    } catch (error) {
+      expect(error.message).toEqual('Cannot hae more than 100 options in a group');
+      done();
+    }
+  });
+
+  it('should throw an error if more than one option has the same value', done => {
+    try {
+      const options = new OptionGroup('options', [new Option('Option', 'option'), new Option('Option', 'option')]);
+    } catch (error) {
+      expect(error.message).toEqual("Two options cannot share the same value in one group: 'option'");
+      done();
+    }
+  });
+
+  it('should create a group', () => {
+    const options = new OptionGroup('options', [new Option('Option', 'option')]);
+
+    expect(options).toEqual({
+      label: {
+        text: 'options',
+        type: 'plain_text',
+      },
+      options: [
+        {
+          text: {
+            text: 'Option',
+            type: 'plain_text',
+          },
+          value: 'option',
+        },
+      ],
+    });
+  });
+});

--- a/src/CompositionObjects/__tests__/OptionGroup.spec.ts
+++ b/src/CompositionObjects/__tests__/OptionGroup.spec.ts
@@ -12,7 +12,7 @@ describe('OptionGroup', () => {
 
       const og = new OptionGroup('options', options);
     } catch (error) {
-      expect(error.message).toEqual('Cannot hae more than 100 options in a group');
+      expect(error.message).toEqual('Cannot have more than 100 options in a group');
       done();
     }
   });

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -1,3 +1,5 @@
+import Option from '../CompositionObjects/Option';
+
 export class Helpers {
   /**
    * @description Validate a strings character length
@@ -8,6 +10,38 @@ export class Helpers {
   public static validateString(param: string, paramName: string, characterLength: number): void {
     if (param.length > characterLength) {
       throw new Error(`${paramName} should not be more than ${characterLength} characters.`);
+    }
+  }
+
+  /**
+   * @description Ensure thant no two options have the same value
+   * @param  {Option[]} options
+   * @returns void
+   */
+  public static validateOptions(options: Option[]): void {
+    const optionsValues: { [k: string]: boolean } = {};
+
+    for (const option of options) {
+      const value = option.value;
+
+      if (optionsValues[value]) {
+        throw new Error(`Two options cannot share the same value in one group: '${value}'`);
+      }
+
+      optionsValues[value] = true;
+    }
+  }
+
+  /**
+   * @description Ensure an array is larger than expected
+   * @param  {any[]} array The array to be tested
+   * @param  {number} maxLength The expected max length of the array
+   * @param  {string} errorMsg The error message to be displayed if the condition is not met
+   * @returns void
+   */
+  public static validateArrayLength(array: any[], maxLength: number, errorMsg: string): void {
+    if (array.length > maxLength) {
+      throw new Error(errorMsg);
     }
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import Image from './Blocks/Image';
 import Section from './Blocks/Section';
 import ConfirmationDialog from './CompositionObjects/ConfirmationDialog';
 import Option from './CompositionObjects/Option';
+import OptionGroup from './CompositionObjects/OptionGroup';
 import Text, { TextType } from './CompositionObjects/Text';
 
 export {
@@ -23,6 +24,7 @@ export {
   Image,
   ImageElement,
   Option,
+  OptionGroup,
   Section,
   Text,
   TextType,

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import Context from './Blocks/Context';
 import Image from './Blocks/Image';
 import Section from './Blocks/Section';
 import ConfirmationDialog from './CompositionObjects/ConfirmationDialog';
+import Option from './CompositionObjects/Option';
 import Text, { TextType } from './CompositionObjects/Text';
 
 export {
@@ -21,6 +22,7 @@ export {
   Context,
   Image,
   ImageElement,
+  Option,
   Section,
   Text,
   TextType,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import BlockElement, { BlockElementType } from './BlockElements/BlockElement';
 import ButtonElement, { ButtonStyle } from './BlockElements/ButtonElement';
 import ImageElement from './BlockElements/ImageElement';
+import StaticSelectElement from './BlockElements/StaticSelectElement';
 import Actions from './Blocks/Actions';
 import Block, { BlockType } from './Blocks/Block';
 import Context from './Blocks/Context';
@@ -26,6 +27,7 @@ export {
   Option,
   OptionGroup,
   Section,
+  StaticSelectElement,
   Text,
   TextType,
 };


### PR DESCRIPTION
# Add Static Select Class

## What does this PR do

This PR adds the StaticSelectElement class

## Background context

The static select element helps render a select menu on slack

## Task completed (detailed list of changes/additions)

- [x] add option class
- [x] add option group class
- [x] add static select class
- [x] add select class
- [x] add documentation
- [x] add helper methods