### PR TITLE
Add User Select

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,12 @@ This is a simple library that helps build slack block messages and all it's elem
         - [Adding options (StaticSelect)](#Adding-options-StaticSelect)
         - [Adding a confirmation dialog (StaticSelectElement)](#Adding-a-confirmation-dialog-StaticSelectElement)
         - [Possible Errors (StaticSelect)](#Possible-Errors-StaticSelect)
+      - [User Select](#User-Select)
+        - [Importing the UserSelectElement Class](#Importing-the-UserSelectElement-Class)
+        - [Creating a User Select Object](#Creating-a-User-Select-Object)
+        - [Adding an initial_user (UserSelect)](#Adding-an-initialuser-UserSelect)
+        - [Adding a confirmation dialog (UserSelectElement)](#Adding-a-confirmation-dialog-UserSelectElement)
+        - [Possible Errors (UserSelect)](#Possible-Errors-UserSelect)
     - [Composition Objects](#Composition-Objects)
       - [Text](#Text)
         - [Importing the Text Class](#Importing-the-Text-Class)
@@ -90,6 +96,8 @@ This library is still in active development and only the following classes are c
 
 > - **Image** > <https://api.slack.com/reference/messaging/block-elements#image>
 > - **Button** > <https://api.slack.com/reference/messaging/block-elements#button>
+> - **StaticSelect** > <https://api.slack.com/reference/messaging/block-elements#static-select>
+> - **UserSelect** > <https://api.slack.com/reference/messaging/block-elements#users-select>
 
 - Composition Objects
 
@@ -701,6 +709,80 @@ sse.addOptionGroups([
 | 'Cannot have more than 100 optionGroups' | Adding more than 100 options in the optionGroups array | Max optionGroups array size should be 100 |
 | 'initialOptionGroupIndex is out of optionGroup range' | Selecting an optionGroupIndex that is beyond the optionGroups array ranch | Use an initialOptionGroupIndex in the optionGroups array range|
 | 'initialOptionIndex is out of options range' | selecting an initialOptionIndex that is beyond the options array range | Use an initialOptionIndex that is in the option array range |
+
+#### User Select
+
+![User Select](https://res.cloudinary.com/iyikuyoro/image/upload/v1563182440/slack-block-msg-kit/Screenshot_2019-07-15_at_10.17.21_AM.png)
+
+A user select menu is a select menu that displays all the members of a slack workspace for selection.
+
+##### Importing the UserSelectElement Class
+
+```javascript
+import UserSelectElement from 'slack-block-msg-kit/BlockElements/UserSelectElement';
+```
+
+or
+
+```javascript
+import { UserSelectElement } from 'slack-block-msg-kit';
+```
+
+##### Creating a User Select Object
+
+| Parameter | Type | Description | Example |
+| --------- | ---- | ----------- | ------- |
+| actionId  | string | The action id of the select element | 'ACT001' |
+| placeholder | string | The placeholder text for the select element | 'select an option' |
+
+Creating a user select object is done by passing the two required parameters to the constructor.
+
+```javascript
+import UserSelectElement from 'slack-block-msg-kit/BlockElements/UserSelectElement';
+
+const use = new UserSelectElement('actionId', 'placeholder');
+```
+
+##### Adding an initial_user (UserSelect)
+
+An initial user can be selected by default when the select menu is loaded on slack. It is one of the optional parameters that can be added to the user select object. To add an initial_user, simply make use of the **addInitialUser** method.
+
+| Parameter | Type | Description | Example |
+| --------- | ---- | ----------- | ------- |
+| initialUserId  | string | The initial user's slack id | 'CT001122' |
+
+```javascript
+import UserSelectElement from 'slack-block-msg-kit/BlockElements/UserSelectElement';
+
+const use = new UserSelectElement('actionId', 'placeholder');
+
+use.addInitialUser('CT001122');
+```
+
+##### Adding a confirmation dialog (UserSelectElement)
+
+You may wish to confirm the user selection with a [Confirmation Dialog](#Confirmation-Dialog). Simply make use of the (**addConfirmationDialogByParameters**) method for this.
+
+```javascript
+import UserSelectElement from 'slack-block-msg-kit/BlockElements/UserSelectElement';
+import Text, { TextType } from 'slack-block-msg-kit/CompositionObjects/Text'
+
+const use = new UserSelectElement('actionId', 'placeholder');
+
+use.addConfirmationDialogByParameters(
+  'confirm',
+  new Text(TextType.plainText, 'Are you sure?'),
+  'Yes',
+  'No',
+);
+```
+
+##### Possible Errors (UserSelect)
+
+| Error | Cause | Remedy |
+| ----- | ----- | ------ |
+| 'placeholder should not be more than 150 characters.' | Adding more than 150 characters in the placeholder | Reduce the placeholder size |
+| 'actionId should not be more than 255 characters.' | Adding more than 255 characters in the actionId | Reduce the actionId size |
 
 ### Composition Objects
 

--- a/src/BlockElements/UserSelectElement.ts
+++ b/src/BlockElements/UserSelectElement.ts
@@ -1,0 +1,52 @@
+import ConfirmationDialog from '../CompositionObjects/ConfirmationDialog';
+import Text from '../CompositionObjects/Text';
+import { BlockElementType } from './BlockElement';
+import SelectElement from './SelectElement';
+
+/**
+ * @description This is the user select element class.
+ * For more info regarding static select elements, kindly visit https://api.slack.com/reference/messaging/block-elements#users-select
+ */
+export default class UserSelectElement extends SelectElement {
+  public initial_user?: string;
+  public confirm?: ConfirmationDialog;
+
+  /**
+   * @description Create an instance of the user select element
+   * @param  {string} actionId The action id of the select element
+   * @param  {string} placeholder The placeholder text of the select element
+   */
+  constructor(actionId: string, placeholder: string) {
+    super(BlockElementType.selectUser, actionId, placeholder);
+  }
+
+  /**
+   * @description Add the initial user
+   * @param  {string} initialUserId The default selected user's slack id
+   * @returns UserSelectElement
+   */
+  public addInitialUser(initialUserId: string): UserSelectElement {
+    this.initial_user = initialUserId;
+    return this;
+  }
+
+  /**
+   * @description Add a confirmation dialog by providing the parameters that is displayed when an option is selected.
+   * This method will create the confirmation dialog.
+   * @param  {string} dialogTitle The dialog title
+   * @param  {Text} dialogText The message to be displayed in the dialog
+   * @param  {string} confirmButton The confirm button label text
+   * @param  {string} denyButton The deny button text
+   * @returns ButtonElement
+   */
+  public addConfirmationDialogByParameters(
+    dialogTitle: string,
+    dialogText: Text,
+    confirmButton: string,
+    denyButton: string,
+  ): UserSelectElement {
+    this.confirm = new ConfirmationDialog(dialogTitle, dialogText, confirmButton, denyButton);
+
+    return this;
+  }
+}

--- a/src/BlockElements/__tests__/UserSelectElement.spec.ts
+++ b/src/BlockElements/__tests__/UserSelectElement.spec.ts
@@ -1,0 +1,58 @@
+import Text, { TextType } from '../../CompositionObjects/Text';
+import UserSelectElement from '../UserSelectElement';
+
+describe('UserSelectElement', () => {
+  it('should create a new user select element', () => {
+    const userSelect = new UserSelectElement('ACT001', 'placeholder');
+
+    expect(userSelect).toEqual({
+      action_id: 'ACT001',
+      placeholder: {
+        text: 'placeholder',
+        type: 'plain_text',
+      },
+      type: 'users_select',
+    });
+  });
+
+  describe('addInitialUser()', () => {
+    const userSelect = new UserSelectElement('ACT001', 'placeholder');
+
+    userSelect.addInitialUser('CD001122');
+
+    expect(userSelect).toEqual({
+      action_id: 'ACT001',
+      initial_user: 'CD001122',
+      placeholder: {
+        text: 'placeholder',
+        type: 'plain_text',
+      },
+      type: 'users_select',
+    });
+  });
+
+  describe('addConfirmationDialogByParameters()', () => {
+    const userSelect = new UserSelectElement('ACT001', 'placeholder');
+
+    userSelect.addConfirmationDialogByParameters('Confirm', new Text(TextType.plainText, 'dialog text'), 'Yes', 'No');
+
+    expect(userSelect.confirm).toEqual({
+      confirm: {
+        text: 'Yes',
+        type: 'plain_text',
+      },
+      deny: {
+        text: 'No',
+        type: 'plain_text',
+      },
+      text: {
+        text: 'dialog text',
+        type: 'plain_text',
+      },
+      title: {
+        text: 'Confirm',
+        type: 'plain_text',
+      },
+    });
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import BlockElement, { BlockElementType } from './BlockElements/BlockElement';
 import ButtonElement, { ButtonStyle } from './BlockElements/ButtonElement';
 import ImageElement from './BlockElements/ImageElement';
 import StaticSelectElement from './BlockElements/StaticSelectElement';
+import UserSelectElement from './BlockElements/UserSelectElement';
 import Actions from './Blocks/Actions';
 import Block, { BlockType } from './Blocks/Block';
 import Context from './Blocks/Context';
@@ -28,6 +29,7 @@ export {
   OptionGroup,
   Section,
   StaticSelectElement,
+  UserSelectElement,
   Text,
   TextType,
 };


### PR DESCRIPTION
# Add User Select

## What does this PR do

This PR adds the user select menu to the library

## Background context

The user select menu helps create a select menu on slack with a list of all users in the workspace.

## Task completed (detailed list of changes/additions)

- [x] add user select class
- [x] add user select documentation