### PR TITLE
Add Conversation Select

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,9 @@ This library is still in active development and only the following classes are c
 
 > - **[Image](https://github.com/IyiKuyoro/slack-block-msg-kit/blob/master/docs/BlockElements/ImageElement.md)**
 > - **[Button](https://github.com/IyiKuyoro/slack-block-msg-kit/blob/master/docs/BlockElements/ButtonElement.md)**
-> - **[StaticSelect](https://github.com/IyiKuyoro/slack-block-msg-kit/blob/master/docs/BlockElements/StaticSelect.md)**
-> - **[UserSelect](https://github.com/IyiKuyoro/slack-block-msg-kit/blob/master/docs/BlockElements/UserSelect.md)**
+> - **[StaticSelect](https://github.com/IyiKuyoro/slack-block-msg-kit/blob/master/docs/BlockElements/StaticSelectElement.md)**
+> - **[UserSelect](https://github.com/IyiKuyoro/slack-block-msg-kit/blob/master/docs/BlockElements/UserSelectElement.md)**
+> - **[ConversationSelect](https://github.com/IyiKuyoro/slack-block-msg-kit/blob/master/docs/BlockElements/ConversationSelectElement.md)**
 
 - [Composition Objects](https://github.com/IyiKuyoro/slack-block-msg-kit/blob/master/docs/CompositionObjects/CompositionObjects.md)
 

--- a/docs/BlockElements/ConversationSelectElement.md
+++ b/docs/BlockElements/ConversationSelectElement.md
@@ -1,0 +1,81 @@
+# Conversation Select
+
+![Conversation Select](https://res.cloudinary.com/iyikuyoro/image/upload/v1563224247/slack-block-msg-kit/Screenshot_2019-07-15_at_9.56.26_PM.png)
+
+A [conversation select](https://api.slack.com/reference/messaging/block-elements#conversation-select) menu lists the available channels and DM to the user on slack.
+
+## Table of Content
+
+- [Conversation Select](#Conversation-Select)
+  - [Table of Content](#Table-of-Content)
+  - [Importing the ConversationSelectElement Class](#Importing-the-ConversationSelectElement-Class)
+  - [Creating a Conversation Select Object (Constructor)](#Creating-a-Conversation-Select-Object-Constructor)
+  - [Adding an initial_conversation (addInitialConversation())](#Adding-an-initialconversation-addInitialConversation)
+  - [Adding a confirmation dialog (addConfirmationDialogByParameters())](#Adding-a-confirmation-dialog-addConfirmationDialogByParameters)
+  - [Possible Errors](#Possible-Errors)
+
+## Importing the ConversationSelectElement Class
+
+```javascript
+import ConversationSelectElement from 'slack-block-msg-kit/BlockElements/ConversationSelectElement';
+```
+
+or
+
+```javascript
+import { ConversationSelectElement } from 'slack-block-msg-kit';
+```
+
+## Creating a Conversation Select Object (Constructor)
+
+| Parameter | Type | Description | Example |
+| --------- | ---- | ----------- | ------- |
+| actionId  | string | The action id of the select element | 'ACT001' |
+| placeholder | string | The placeholder text for the select element | 'select an option' |
+
+```javascript
+import { ConversationSelectElement } from 'slack-block-msg-kit';
+
+const convSelect = new ConversationSelectElement('actionId', 'placeholder');
+```
+
+## Adding an initial_conversation (addInitialConversation())
+
+An initial conversation can be selected by default when the select menu is loaded on slack. It is one of the optional parameters that can be added to the conversation select object. To add an initial_conversation, simply make use of the **addInitialConversation** method.
+
+| Parameter | Type | Description | Example |
+| --------- | ---- | ----------- | ------- |
+| initialConversationId  | string | The initial conversation's slack id | 'CT001122' |
+
+```javascript
+import { ConversationSelectElement } from 'slack-block-msg-kit';
+
+const convSelect = new ConversationSelectElement('actionId', 'placeholder');
+
+convSelect.addInitialConversation('CT001122');
+```
+
+## Adding a confirmation dialog (addConfirmationDialogByParameters())
+
+You may wish to confirm the user selection with a [Confirmation Dialog](https://github.com/IyiKuyoro/slack-block-msg-kit/blob/master/docs/CompositionObjects/ConfirmationDialog.md). Simply make use of the (**addConfirmationDialogByParameters**) method for this.
+
+```javascript
+import Text, { TextType } from 'slack-block-msg-kit/CompositionObjects/Text'
+import { ConversationSelectElement } from 'slack-block-msg-kit';
+
+const convSelect = new ConversationSelectElement('actionId', 'placeholder');
+
+convSelect.addConfirmationDialogByParameters(
+  'confirm',
+  new Text(TextType.plainText, 'Are you sure?'),
+  'Yes',
+  'No',
+);
+```
+
+## Possible Errors
+
+| Error | Cause | Remedy |
+| ----- | ----- | ------ |
+| 'placeholder should not be more than 150 characters.' | Adding more than 150 characters in the placeholder | Reduce the placeholder size |
+| 'actionId should not be more than 255 characters.' | Adding more than 255 characters in the actionId | Reduce the actionId size |

--- a/docs/BlockElements/UserSelectElement.md
+++ b/docs/BlockElements/UserSelectElement.md
@@ -4,15 +4,15 @@
 
 A user select menu is a select menu that displays all the members of a slack workspace for selection.
 
-## Table pf Content
+## Table of Content
 
 - [User Select](#User-Select)
-  - [Table pf Content](#Table-pf-Content)
+  - [Table of Content](#Table-of-Content)
   - [Importing the UserSelectElement Class](#Importing-the-UserSelectElement-Class)
   - [Creating a User Select Object (Constructor)](#Creating-a-User-Select-Object-Constructor)
   - [Adding an initial_user (addInitialUser())](#Adding-an-initialuser-addInitialUser)
   - [Adding a confirmation dialog (addConfirmationDialogByParameters())](#Adding-a-confirmation-dialog-addConfirmationDialogByParameters)
-  - [Possible Errors (UserSelect)](#Possible-Errors-UserSelect)
+  - [Possible Errors](#Possible-Errors)
 
 ## Importing the UserSelectElement Class
 
@@ -75,7 +75,7 @@ use.addConfirmationDialogByParameters(
 );
 ```
 
-## Possible Errors (UserSelect)
+## Possible Errors
 
 | Error | Cause | Remedy |
 | ----- | ----- | ------ |

--- a/src/BlockElements/ConversationSelectElement.ts
+++ b/src/BlockElements/ConversationSelectElement.ts
@@ -1,0 +1,29 @@
+import { BlockElementType } from './BlockElement';
+import SelectElement from './SelectElement';
+
+/**
+ * @description This is the conversation select element class.
+ * For more info regarding this, kindly visit https://api.slack.com/reference/messaging/block-elements#conversation-select
+ */
+export default class ConversationSelectElement extends SelectElement {
+  public initial_conversation?: string;
+
+  /**
+   * @description Create an instance of the conversation select element
+   * @param  {string} actionId The action id for the select element.
+   * @param  {string} placeholder The select element placeholder
+   */
+  constructor(actionId: string, placeholder: string) {
+    super(BlockElementType.selectConversation, actionId, placeholder);
+  }
+
+  /**
+   * @description Add the initial user
+   * @param  {string} initialConversationId The default selected user's slack id
+   * @returns ConversationSelectElement
+   */
+  public addInitialConversation(initialConversationId: string): ConversationSelectElement {
+    this.initial_conversation = initialConversationId;
+    return this;
+  }
+}

--- a/src/BlockElements/SelectElement.ts
+++ b/src/BlockElements/SelectElement.ts
@@ -1,3 +1,4 @@
+import ConfirmationDialog from '../CompositionObjects/ConfirmationDialog';
 import Text, { TextType } from '../CompositionObjects/Text';
 import { Helpers } from '../helpers';
 import BlockElement, { BlockElementType } from './BlockElement';
@@ -8,6 +9,7 @@ import BlockElement, { BlockElementType } from './BlockElement';
  */
 export default abstract class SelectElement extends BlockElement {
   public placeholder: Text;
+  public confirm?: ConfirmationDialog;
 
   /**
    * @description Create a new instance of a select element.
@@ -21,5 +23,25 @@ export default abstract class SelectElement extends BlockElement {
     Helpers.validateString(placeholder, 'placeholder', 150);
 
     this.placeholder = new Text(TextType.plainText, placeholder);
+  }
+
+  /**
+   * @description Add a confirmation dialog by providing the parameters that is displayed when an option is selected.
+   * This method will create the confirmation dialog.
+   * @param  {string} dialogTitle The dialog title
+   * @param  {Text} dialogText The message to be displayed in the dialog
+   * @param  {string} confirmButton The confirm button label text
+   * @param  {string} denyButton The deny button text
+   * @returns ButtonElement
+   */
+  public addConfirmationDialogByParameters(
+    dialogTitle: string,
+    dialogText: Text,
+    confirmButton: string,
+    denyButton: string,
+  ): SelectElement {
+    this.confirm = new ConfirmationDialog(dialogTitle, dialogText, confirmButton, denyButton);
+
+    return this;
   }
 }

--- a/src/BlockElements/StaticSelectElement.ts
+++ b/src/BlockElements/StaticSelectElement.ts
@@ -1,7 +1,5 @@
-import ConfirmationDialog from '../CompositionObjects/ConfirmationDialog';
 import Option from '../CompositionObjects/Option';
 import OptionGroup from '../CompositionObjects/OptionGroup';
-import Text from '../CompositionObjects/Text';
 import { Helpers } from '../helpers';
 import { BlockElementType } from './BlockElement';
 import SelectElement from './SelectElement';
@@ -14,7 +12,6 @@ export default class StaticSelectElement extends SelectElement {
   public options?: Option[];
   public option_groups?: OptionGroup[];
   public initial_option?: Option;
-  public confirm?: ConfirmationDialog;
 
   /**
    * @description Create an instance of the static select element
@@ -65,26 +62,6 @@ export default class StaticSelectElement extends SelectElement {
 
     this.option_groups = optionGroups;
     this.assignInitialOptionOptionGroups(optionGroups, initialOptionGroupIndex, initialOptionIndex);
-
-    return this;
-  }
-
-  /**
-   * @description Add a confirmation dialog by providing the parameters that is displayed when an option is selected.
-   * This method will create the confirmation dialog.
-   * @param  {string} dialogTitle The dialog title
-   * @param  {Text} dialogText The message to be displayed in the dialog
-   * @param  {string} confirmButton The confirm button label text
-   * @param  {string} denyButton The deny button text
-   * @returns ButtonElement
-   */
-  public addConfirmationDialogByParameters(
-    dialogTitle: string,
-    dialogText: Text,
-    confirmButton: string,
-    denyButton: string,
-  ): StaticSelectElement {
-    this.confirm = new ConfirmationDialog(dialogTitle, dialogText, confirmButton, denyButton);
 
     return this;
   }

--- a/src/BlockElements/UserSelectElement.ts
+++ b/src/BlockElements/UserSelectElement.ts
@@ -1,15 +1,12 @@
-import ConfirmationDialog from '../CompositionObjects/ConfirmationDialog';
-import Text from '../CompositionObjects/Text';
 import { BlockElementType } from './BlockElement';
 import SelectElement from './SelectElement';
 
 /**
  * @description This is the user select element class.
- * For more info regarding static select elements, kindly visit https://api.slack.com/reference/messaging/block-elements#users-select
+ * For more info regarding this, kindly visit https://api.slack.com/reference/messaging/block-elements#users-select
  */
 export default class UserSelectElement extends SelectElement {
   public initial_user?: string;
-  public confirm?: ConfirmationDialog;
 
   /**
    * @description Create an instance of the user select element
@@ -27,26 +24,6 @@ export default class UserSelectElement extends SelectElement {
    */
   public addInitialUser(initialUserId: string): UserSelectElement {
     this.initial_user = initialUserId;
-    return this;
-  }
-
-  /**
-   * @description Add a confirmation dialog by providing the parameters that is displayed when an option is selected.
-   * This method will create the confirmation dialog.
-   * @param  {string} dialogTitle The dialog title
-   * @param  {Text} dialogText The message to be displayed in the dialog
-   * @param  {string} confirmButton The confirm button label text
-   * @param  {string} denyButton The deny button text
-   * @returns ButtonElement
-   */
-  public addConfirmationDialogByParameters(
-    dialogTitle: string,
-    dialogText: Text,
-    confirmButton: string,
-    denyButton: string,
-  ): UserSelectElement {
-    this.confirm = new ConfirmationDialog(dialogTitle, dialogText, confirmButton, denyButton);
-
     return this;
   }
 }

--- a/src/BlockElements/__tests__/ConversationSelectElement.spec.ts
+++ b/src/BlockElements/__tests__/ConversationSelectElement.spec.ts
@@ -1,0 +1,34 @@
+import ConversationSelectElement from '../ConversationSelectElement';
+
+describe('ConversationSelectElement', () => {
+  it('should create a new conversation element', () => {
+    const cse = new ConversationSelectElement('ACT001', 'placeholder');
+
+    expect(cse).toEqual({
+      action_id: 'ACT001',
+      placeholder: {
+        text: 'placeholder',
+        type: 'plain_text',
+      },
+      type: 'conversations_select',
+    });
+  });
+
+  describe('addInitialConversation()', () => {
+    it('should add initial conversation', () => {
+      const userSelect = new ConversationSelectElement('ACT001', 'placeholder');
+
+      userSelect.addInitialConversation('CD001122');
+
+      expect(userSelect).toEqual({
+        action_id: 'ACT001',
+        initial_conversation: 'CD001122',
+        placeholder: {
+          text: 'placeholder',
+          type: 'plain_text',
+        },
+        type: 'conversations_select',
+      });
+    });
+  });
+});

--- a/src/BlockElements/__tests__/UserSelectElement.spec.ts
+++ b/src/BlockElements/__tests__/UserSelectElement.spec.ts
@@ -16,43 +16,47 @@ describe('UserSelectElement', () => {
   });
 
   describe('addInitialUser()', () => {
-    const userSelect = new UserSelectElement('ACT001', 'placeholder');
+    it('should add an initial user', () => {
+      const userSelect = new UserSelectElement('ACT001', 'placeholder');
 
-    userSelect.addInitialUser('CD001122');
+      userSelect.addInitialUser('CD001122');
 
-    expect(userSelect).toEqual({
-      action_id: 'ACT001',
-      initial_user: 'CD001122',
-      placeholder: {
-        text: 'placeholder',
-        type: 'plain_text',
-      },
-      type: 'users_select',
+      expect(userSelect).toEqual({
+        action_id: 'ACT001',
+        initial_user: 'CD001122',
+        placeholder: {
+          text: 'placeholder',
+          type: 'plain_text',
+        },
+        type: 'users_select',
+      });
     });
   });
 
   describe('addConfirmationDialogByParameters()', () => {
-    const userSelect = new UserSelectElement('ACT001', 'placeholder');
+    it('should add a confirmation dialog', () => {
+      const userSelect = new UserSelectElement('ACT001', 'placeholder');
 
-    userSelect.addConfirmationDialogByParameters('Confirm', new Text(TextType.plainText, 'dialog text'), 'Yes', 'No');
+      userSelect.addConfirmationDialogByParameters('Confirm', new Text(TextType.plainText, 'dialog text'), 'Yes', 'No');
 
-    expect(userSelect.confirm).toEqual({
-      confirm: {
-        text: 'Yes',
-        type: 'plain_text',
-      },
-      deny: {
-        text: 'No',
-        type: 'plain_text',
-      },
-      text: {
-        text: 'dialog text',
-        type: 'plain_text',
-      },
-      title: {
-        text: 'Confirm',
-        type: 'plain_text',
-      },
+      expect(userSelect.confirm).toEqual({
+        confirm: {
+          text: 'Yes',
+          type: 'plain_text',
+        },
+        deny: {
+          text: 'No',
+          type: 'plain_text',
+        },
+        text: {
+          text: 'dialog text',
+          type: 'plain_text',
+        },
+        title: {
+          text: 'Confirm',
+          type: 'plain_text',
+        },
+      });
     });
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import BlockElement, { BlockElementType } from './BlockElements/BlockElement';
 import ButtonElement, { ButtonStyle } from './BlockElements/ButtonElement';
+import ConversationSelectElement from './BlockElements/ConversationSelectElement';
 import ImageElement from './BlockElements/ImageElement';
 import StaticSelectElement from './BlockElements/StaticSelectElement';
 import UserSelectElement from './BlockElements/UserSelectElement';
@@ -23,6 +24,7 @@ export {
   ButtonStyle,
   ConfirmationDialog,
   Context,
+  ConversationSelectElement,
   Image,
   ImageElement,
   Option,


### PR DESCRIPTION
# Add Conversation Select

## What does this PR do

This PR adds the conversation select class to the library

## Background context

The conversation select class is required to display channels and dms that are available to the user on slack.

## Task completed (detailed list of changes/additions)

- [x] add conversation class
- [x] add conversation documentation
- [x] move confirm field to the select element abstract class
