### PR TITLE
Add Channel Select Class

### DIFF
--- a/docs/BlockElements/ChannelSelectElement.md
+++ b/docs/BlockElements/ChannelSelectElement.md
@@ -1,0 +1,79 @@
+# Channel Select
+
+A [channel select](https://api.slack.com/reference/messaging/block-elements#channel-select) menu lists all the available channels to the current user on slack.
+
+## Table of Content
+
+- [Channel Select](#Channel-Select)
+  - [Table of Content](#Table-of-Content)
+  - [Importing the ChannelSelectElement Class](#Importing-the-ChannelSelectElement-Class)
+  - [Creating a Channel Select Object (Constructor)](#Creating-a-Channel-Select-Object-Constructor)
+  - [Adding an initial_channel (addInitialChannel())](#Adding-an-initialchannel-addInitialChannel)
+  - [Adding a confirmation dialog (addConfirmationDialogByParameters())](#Adding-a-confirmation-dialog-addConfirmationDialogByParameters)
+  - [Possible Errors](#Possible-Errors)
+
+## Importing the ChannelSelectElement Class
+
+```javascript
+import { ChannelSelectElement } from 'slack-block-msg-kit';
+```
+
+or
+
+```javascript
+import ChannelSelectElement from 'slack-block-msg-kit/BlockElements/ChannelSelectElement';
+```
+
+## Creating a Channel Select Object (Constructor)
+
+| Parameter | Type | Description | Example |
+| --------- | ---- | ----------- | ------- |
+| actionId  | string | The action id of the select element | 'ACT001' |
+| placeholder | string | The placeholder text for the select element | 'select an option' |
+
+```javascript
+import ChannelSelectElement from 'slack-block-msg-kit/BlockElements/ChannelSelectElement';
+
+const channelSelect = new ChannelSelectElement('actionId', 'placeholder');
+```
+
+## Adding an initial_channel (addInitialChannel())
+
+An initial channel can be selected by default when the select menu is loaded on slack. It is one of the optional parameters that can be added to the channel select object. To add an initial_channel, simply make use of the **addInitialChannel** method.
+
+| Parameter | Type | Description | Example |
+| --------- | ---- | ----------- | ------- |
+| initialChannelId  | string | The initial channel's slack id | 'CT001122' |
+
+```javascript
+import ChannelSelectElement from 'slack-block-msg-kit/BlockElements/ChannelSelectElement';
+
+const channelSelect = new ChannelSelectElement('actionId', 'placeholder');
+
+channelSelect.addInitialChannel('CT001122');
+```
+
+## Adding a confirmation dialog (addConfirmationDialogByParameters())
+
+You may wish to confirm the user selection with a [Confirmation Dialog](https://github.com/IyiKuyoro/slack-block-msg-kit/blob/master/docs/CompositionObjects/ConfirmationDialog.md). Simply make use of the (**addConfirmationDialogByParameters**) method for this.
+
+```javascript
+import Text, { TextType } from 'slack-block-msg-kit/CompositionObjects/Text'
+import ChannelSelectElement from 'slack-block-msg-kit/BlockElements/ChannelSelectElement';
+
+const channelSelect = new ChannelSelectElement('actionId', 'placeholder');
+
+channelSelect.addConfirmationDialogByParameters(
+  'confirm',
+  new Text(TextType.plainText, 'Are you sure?'),
+  'Yes',
+  'No',
+);
+```
+
+## Possible Errors
+
+| Error | Cause | Remedy |
+| ----- | ----- | ------ |
+| 'placeholder should not be more than 150 characters.' | Adding more than 150 characters in the placeholder | Reduce the placeholder size |
+| 'actionId should not be more than 255 characters.' | Adding more than 255 characters in the actionId | Reduce the actionId size |

--- a/docs/BlockElements/ConversationSelectElement.md
+++ b/docs/BlockElements/ConversationSelectElement.md
@@ -2,7 +2,7 @@
 
 ![Conversation Select](https://res.cloudinary.com/iyikuyoro/image/upload/v1563224247/slack-block-msg-kit/Screenshot_2019-07-15_at_9.56.26_PM.png)
 
-A [conversation select](https://api.slack.com/reference/messaging/block-elements#conversation-select) menu lists the available channels and DM to the user on slack.
+A [conversation select](https://api.slack.com/reference/messaging/block-elements#conversation-select) menu lists the available communications to the user on slack.
 
 ## Table of Content
 

--- a/src/BlockElements/ChannelSelectElement.ts
+++ b/src/BlockElements/ChannelSelectElement.ts
@@ -1,0 +1,28 @@
+import { BlockElementType } from './BlockElement';
+import SelectElement from './SelectElement';
+
+/**
+ * @description This is the channel select element class.
+ * For more info regarding this, kindly visit https://api.slack.com/reference/messaging/block-elements#channel-select
+ */
+export default class ChannelSelectElement extends SelectElement {
+  public initial_channel?: string;
+  /**
+   * @description Create an instance of the channel select element
+   * @param  {string} actionId The action id for the select element.
+   * @param  {string} placeholder The select element placeholder
+   */
+  constructor(actionId: string, placeholder: string) {
+    super(BlockElementType.selectChannel, actionId, placeholder);
+  }
+
+  /**
+   * @description Add the initial channel
+   * @param  {string} initialConversationId The default selected channel's slack id
+   * @returns ChannelSelectElement
+   */
+  public addInitialChannel(initialChannelId: string): ChannelSelectElement {
+    this.initial_channel = initialChannelId;
+    return this;
+  }
+}

--- a/src/BlockElements/ConversationSelectElement.ts
+++ b/src/BlockElements/ConversationSelectElement.ts
@@ -18,8 +18,8 @@ export default class ConversationSelectElement extends SelectElement {
   }
 
   /**
-   * @description Add the initial user
-   * @param  {string} initialConversationId The default selected user's slack id
+   * @description Add the initial conversation
+   * @param  {string} initialConversationId The default selected conversation's slack id
    * @returns ConversationSelectElement
    */
   public addInitialConversation(initialConversationId: string): ConversationSelectElement {

--- a/src/BlockElements/__tests__/ChannelSelectElement.spec.ts
+++ b/src/BlockElements/__tests__/ChannelSelectElement.spec.ts
@@ -1,0 +1,34 @@
+import ChannelSelectElement from '../ChannelSelectElement';
+
+describe('ChannelSelectElement', () => {
+  it('should create a new channel select element', () => {
+    const channelSelect = new ChannelSelectElement('ACT001', 'placeholder');
+
+    expect(channelSelect).toEqual({
+      action_id: 'ACT001',
+      placeholder: {
+        text: 'placeholder',
+        type: 'plain_text',
+      },
+      type: 'channels_select',
+    });
+  });
+
+  describe('addInitialChannel()', () => {
+    it('should add an initial channel to the selection', () => {
+      const channelSelect = new ChannelSelectElement('ACT001', 'placeholder');
+
+      channelSelect.addInitialChannel('CT001222');
+
+      expect(channelSelect).toEqual({
+        action_id: 'ACT001',
+        initial_channel: 'CT001222',
+        placeholder: {
+          text: 'placeholder',
+          type: 'plain_text',
+        },
+        type: 'channels_select',
+      });
+    });
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import BlockElement, { BlockElementType } from './BlockElements/BlockElement';
 import ButtonElement, { ButtonStyle } from './BlockElements/ButtonElement';
+import ChannelSelectElement from './BlockElements/ChannelSelectElement';
 import ConversationSelectElement from './BlockElements/ConversationSelectElement';
 import ImageElement from './BlockElements/ImageElement';
 import StaticSelectElement from './BlockElements/StaticSelectElement';
@@ -22,6 +23,7 @@ export {
   BlockElementType,
   ButtonElement,
   ButtonStyle,
+  ChannelSelectElement,
   ConfirmationDialog,
   Context,
   ConversationSelectElement,


### PR DESCRIPTION
# Add Channel Menu

## What does this PR do

This PR adds the channel select menu class

## Background context

The channel select menu is required for selecting channels that are available to a user on slack

## Task completed (detailed list of changes/additions)

- [x] add channel select class
- [x] add channel select test
- [x] modify conversation select docs