### PR TITLE
Add Overflow Menu Element

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ This library is still in active development and only the following classes are c
 > - **[StaticSelect](https://github.com/IyiKuyoro/slack-block-msg-kit/blob/master/docs/BlockElements/StaticSelectElement.md)**
 > - **[UserSelect](https://github.com/IyiKuyoro/slack-block-msg-kit/blob/master/docs/BlockElements/UserSelectElement.md)**
 > - **[ConversationSelect](https://github.com/IyiKuyoro/slack-block-msg-kit/blob/master/docs/BlockElements/ConversationSelectElement.md)**
+> - **[ChannelSelect](https://github.com/IyiKuyoro/slack-block-msg-kit/blob/master/docs/BlockElements/ChannelSelectElement.md)**
+> - **[OverflowMenu](https://github.com/IyiKuyoro/slack-block-msg-kit/blob/master/docs/BlockElements/OverflowMenuElement.md)**
 
 - [Composition Objects](https://github.com/IyiKuyoro/slack-block-msg-kit/blob/master/docs/CompositionObjects/CompositionObjects.md)
 

--- a/docs/BlockElements/OverflowMenuElement.md
+++ b/docs/BlockElements/OverflowMenuElement.md
@@ -1,0 +1,65 @@
+# Overflow Menu
+
+![Overflow Menu](https://res.cloudinary.com/iyikuyoro/image/upload/v1563276895/slack-block-msg-kit/Screenshot_2019-07-16_at_12.33.41_PM.png)
+
+An [overflow menu](https://api.slack.com/reference/messaging/block-elements#overflow) renders a list of options on slack hidden behind an ellipsis.
+
+## Importing the Overflow Menu Class
+
+```javascript
+import { OverflowMenuElement } from 'slack-block-msg-kit';
+```
+
+or
+
+```javascript
+import OverflowMenuElement from 'slack-block-msg-kit/BlockElements/OverflowMenuElement';
+```
+
+## Creating an Overflow Menu Object (Constructor)
+
+| Parameter | Type | Description | Example |
+| --------- | ---- | ----------- | ------- |
+| actionId  | string | The action id of the select element | 'ACT001' |
+| options | [Option](https://github.com/IyiKuyoro/slack-block-msg-kit/blob/master/docs/CompositionObjects/Option.md)[] | An array of options | [new Option('Option 1', 'value 1'), new Option('Option 2', 'value 2')] |
+
+Creating an overflow menu is done by passing two required parameters to the constructor.
+
+```javascript
+import Option from 'slack-block-msg-kit/CompositionObjects/Option';
+import OverflowMenuElement from 'slack-block-msg-kit/BlockElements/OverflowMenuElement';
+
+const overflowMenu = new OverflowMenuElement('actionId', [
+  new Option('Option 1', 'value 1'),
+  new Option('Option 2', 'value 2'),
+]);
+```
+
+## Adding a confirmation dialog (.addConfirmationDialogByParameters())
+
+You may wish to confirm the user selection with a [Confirmation Dialog](https://github.com/IyiKuyoro/slack-block-msg-kit/blob/master/docs/CompositionObjects/ConfirmationDialog.md). Simply make use of the (**addConfirmationDialogByParameters**) method for this.
+
+```javascript
+import Text, { TextType } from 'slack-block-msg-kit/CompositionObjects/Text'
+import Option from 'slack-block-msg-kit/CompositionObjects/Option';
+import OverflowMenuElement from 'slack-block-msg-kit/BlockElements/OverflowMenuElement';
+
+const overflowMenu = new OverflowMenuElement('actionId', [
+  new Option('Option 1', 'value 1'),
+  new Option('Option 2', 'value 2'),
+]);
+
+overflowMenu.addConfirmationDialogByParameters(
+  'confirm',
+  new Text(TextType.plainText, 'Are you sure?'),
+  'Yes',
+  'No',
+);
+```
+
+| Error | Cause | Remedy |
+| ----- | ----- | ------ |
+| 'actionId should not be more than 255 characters.' | Adding more than 255 characters in the actionId | Reduce the actionId size |
+| 'Minimum of two options allowed' | Adding less that two options in the menu | Consider using a button |
+| 'Maximum of five options allowed' | Adding more than five options in the menu | Consider using a select menu |
+| 'Two options cannot share the same value in one group: 'value'' | Having two options with the same value | Use unique values for each option. |

--- a/src/BlockElements/OverflowMenuElement.ts
+++ b/src/BlockElements/OverflowMenuElement.ts
@@ -1,0 +1,60 @@
+import ConfirmationDialog from '../CompositionObjects/ConfirmationDialog';
+import Option from '../CompositionObjects/Option';
+import Text from '../CompositionObjects/Text';
+import { Helpers } from '../helpers';
+import BlockElement, { BlockElementType } from './BlockElement';
+
+/**
+ * @description This is the overflow menu element class.
+ * For more info regarding this, kindly visit https://api.slack.com/reference/messaging/block-elements#overflow
+ */
+export default class OverflowMenuElement extends BlockElement {
+  public options: Option[];
+  public confirm?: ConfirmationDialog;
+
+  /**
+   * @description Create new overflow menu element
+   * @param  {string} actionId The action id of the overflow menu
+   * @param  {Option[]} options An array of options to be added to the menu
+   */
+  constructor(actionId: string, options: Option[]) {
+    super(BlockElementType.overflow, actionId);
+
+    this.validateOptionsLength(options);
+    Helpers.validateOptions(options);
+
+    this.options = options;
+  }
+
+  /**
+   * @description Add a confirmation dialog by providing the parameters that is displayed when an option is selected.
+   * This method will create the confirmation dialog.
+   * @param  {string} dialogTitle The dialog title
+   * @param  {Text} dialogText The message to be displayed in the dialog
+   * @param  {string} confirmButton The confirm button label text
+   * @param  {string} denyButton The deny button text
+   * @returns ButtonElement
+   */
+  public addConfirmationDialogByParameters(
+    dialogTitle: string,
+    dialogText: Text,
+    confirmButton: string,
+    denyButton: string,
+  ): OverflowMenuElement {
+    this.confirm = new ConfirmationDialog(dialogTitle, dialogText, confirmButton, denyButton);
+
+    return this;
+  }
+
+  /**
+   * @description Ensure option is of the right size
+   * @param  {Option[]} options
+   */
+  private validateOptionsLength(options: Option[]) {
+    if (options.length < 2) {
+      throw new Error('Minimum of two options allowed');
+    } else if (options.length > 5) {
+      throw new Error('Maximum of five options allowed');
+    }
+  }
+}

--- a/src/BlockElements/__tests__/OverflowMenuElement.spec.ts
+++ b/src/BlockElements/__tests__/OverflowMenuElement.spec.ts
@@ -1,0 +1,101 @@
+import Option from '../../CompositionObjects/Option';
+import Text, { TextType } from '../../CompositionObjects/Text';
+import OverflowMenuElement from '../OverflowMenuElement';
+
+describe('OverflowMenuElement', () => {
+  it('should create a new overflow menu', () => {
+    const overflow = new OverflowMenuElement('ACT001', [
+      new Option('Option 1', 'value 1'),
+      new Option('Option 2', 'value 2'),
+    ]);
+
+    expect(overflow).toEqual({
+      action_id: 'ACT001',
+      options: [
+        {
+          text: {
+            text: 'Option 1',
+            type: 'plain_text',
+          },
+          value: 'value 1',
+        },
+        {
+          text: {
+            text: 'Option 2',
+            type: 'plain_text',
+          },
+          value: 'value 2',
+        },
+      ],
+      type: 'overflow',
+    });
+  });
+
+  it('should throw an error if options are less than two', done => {
+    try {
+      const overflow = new OverflowMenuElement('ACT001', [new Option('Option 1', 'value 1')]);
+    } catch (error) {
+      expect(error.message).toEqual('Minimum of two options allowed');
+      done();
+    }
+  });
+
+  it('should throw an error if options are less than two', done => {
+    try {
+      const overflow = new OverflowMenuElement('ACT001', [
+        new Option('Option 1', 'value 1'),
+        new Option('Option 2', 'value 2'),
+        new Option('Option 3', 'value 3'),
+        new Option('Option 4', 'value 4'),
+        new Option('Option 5', 'value 5'),
+        new Option('Option 6', 'value 6'),
+      ]);
+    } catch (error) {
+      expect(error.message).toEqual('Maximum of five options allowed');
+      done();
+    }
+  });
+
+  it('should throw an error if two options have the same value', done => {
+    try {
+      const overflow = new OverflowMenuElement('ACT001', [
+        new Option('Option 1', 'value 1'),
+        new Option('Option 2', 'value 2'),
+        new Option('Option 3', 'value 2'),
+      ]);
+    } catch (error) {
+      expect(error.message).toEqual("Two options cannot share the same value in one group: 'value 2'");
+      done();
+    }
+  });
+
+  describe('addConfirmationDialogByParameters()', () => {
+    it('should add a confirmation dialog to the menu', () => {
+      const overflow = new OverflowMenuElement('ACT001', [
+        new Option('Option 1', 'value 1'),
+        new Option('Option 2', 'value 2'),
+      ]);
+
+      overflow.addConfirmationDialogByParameters('Confirm', new Text(TextType.plainText, 'dialog text'), 'Yes', 'No');
+
+      expect(overflow.confirm).toEqual({
+        confirm: {
+          text: 'Yes',
+          type: 'plain_text',
+        },
+        deny: {
+          text: 'No',
+          type: 'plain_text',
+        },
+        text: {
+          text: 'dialog text',
+          type: 'plain_text',
+        },
+        title: {
+          text: 'Confirm',
+          type: 'plain_text',
+        },
+      });
+    });
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import ButtonElement, { ButtonStyle } from './BlockElements/ButtonElement';
 import ChannelSelectElement from './BlockElements/ChannelSelectElement';
 import ConversationSelectElement from './BlockElements/ConversationSelectElement';
 import ImageElement from './BlockElements/ImageElement';
+import OverflowMenuElement from './BlockElements/OverflowMenuElement';
 import StaticSelectElement from './BlockElements/StaticSelectElement';
 import UserSelectElement from './BlockElements/UserSelectElement';
 import Actions from './Blocks/Actions';
@@ -31,6 +32,7 @@ export {
   ImageElement,
   Option,
   OptionGroup,
+  OverflowMenuElement,
   Section,
   StaticSelectElement,
   UserSelectElement,


### PR DESCRIPTION
# Add Overflow Menu Element

## What does this PR do

This PR adds the overflow menu element

## Background context

The overflow menu elements allow options to be hidden behind an ellipsis.

## Task completed (detailed list of changes/additions)

- [x] add overflow menu class
- [x] add overflow menu test
- [x] add overflow documentation