### PR TITLE
Add Date Picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ This library is still in active development and only the following classes are c
 > - **[ConversationSelect](https://github.com/IyiKuyoro/slack-block-msg-kit/blob/master/docs/BlockElements/ConversationSelectElement.md)**
 > - **[ChannelSelect](https://github.com/IyiKuyoro/slack-block-msg-kit/blob/master/docs/BlockElements/ChannelSelectElement.md)**
 > - **[OverflowMenu](https://github.com/IyiKuyoro/slack-block-msg-kit/blob/master/docs/BlockElements/OverflowMenuElement.md)**
+> - **[DatePicker](https://github.com/IyiKuyoro/slack-block-msg-kit/blob/master/docs/BlockElements/DatePickerElement.md)**
 
 - [Composition Objects](https://github.com/IyiKuyoro/slack-block-msg-kit/blob/master/docs/CompositionObjects/CompositionObjects.md)
 

--- a/docs/BlockElements/DatePickerElement.md
+++ b/docs/BlockElements/DatePickerElement.md
@@ -1,0 +1,104 @@
+# Date Picker
+
+![Date picker image](https://res.cloudinary.com/iyikuyoro/image/upload/v1563297584/slack-block-msg-kit/Screenshot_2019-07-16_at_6.19.23_PM.png)
+
+A [date picker](https://api.slack.com/reference/messaging/block-elements#datepicker) renders allows users to select a date from a calender on slack.
+
+## table of Content
+
+- [Date Picker](#Date-Picker)
+  - [table of Content](#table-of-Content)
+  - [Importing the Date Picker Class](#Importing-the-Date-Picker-Class)
+  - [Creating a Date Picker Object (Constructor)](#Creating-a-Date-Picker-Object-Constructor)
+  - [Adding a Placeholder (addPlaceholder())](#Adding-a-Placeholder-addPlaceholder)
+  - [Adding an initial Date (addInitialDate())](#Adding-an-initial-Date-addInitialDate)
+  - [Adding a confirmation dialog (addConfirmationDialogByParameters())](#Adding-a-confirmation-dialog-addConfirmationDialogByParameters)
+  - [Possible Errors](#Possible-Errors)
+
+## Importing the Date Picker Class
+
+```javascript
+import { DatePickerElement } from 'slack-block-msg-kit';
+```
+
+or
+
+```javascript
+import DatePickerElement from 'slack-block-msg-kit/BlockElements/DatePickerElement';
+```
+
+## Creating a Date Picker Object (Constructor)
+
+| Parameter | Type | Description | Example |
+| --------- | ---- | ----------- | ------- |
+| actionId  | string | The action id of the date picker element | 'ACT001' |
+
+A date picker is easily created by passing an action id as the only required parameter to the constructor
+
+```javascript
+import DatePickerElement from 'slack-block-msg-kit/BlockElements/DatePickerElement';
+
+const datePicker = new DatePickerElement('ACT001');
+```
+
+## Adding a Placeholder (addPlaceholder())
+
+| Parameter | Type | Description | Example |
+| --------- | ---- | ----------- | ------- |
+| placeholder | string | The text to be rendered as the placeholder | 'Select a date' |
+
+A custom placeholder can be added to the date picker by passing a string to the **addPlaceholder** method.
+
+```javascript
+import DatePickerElement from 'slack-block-msg-kit/BlockElements/DatePickerElement';
+
+const datePicker = new DatePickerElement('ACT001');
+
+datePicker.addPlaceholder('Select a date');
+```
+
+## Adding an initial Date (addInitialDate())
+
+| Parameter | Type | Description | Example |
+| --------- | ---- | ----------- | ------- |
+| year | number | The year of the date to be selected | 2019 |
+| month | number | The month of the date to be selected | 2 |
+| day | number | The day of the date to be selected | 28 |
+
+You can add an initial date to be selected when the date picker is loaded up on slack. To do this, make use of the **addInitialDate** method, passing along three required parameters.
+
+```javascript
+import DatePickerElement from 'slack-block-msg-kit/BlockElements/DatePickerElement';
+
+const datePicker = new DatePickerElement('ACT001');
+
+datePicker.addInitialDate(2020, 2, 29);
+```
+
+## Adding a confirmation dialog (addConfirmationDialogByParameters())
+
+You may wish to confirm the user's date selection with a [Confirmation Dialog](https://github.com/IyiKuyoro/slack-block-msg-kit/blob/master/docs/CompositionObjects/ConfirmationDialog.md). Simply make use of the (**addConfirmationDialogByParameters**) method for this.
+
+```javascript
+import Text, { TextType } from 'slack-block-msg-kit/CompositionObjects/Text'
+import DatePickerElement from 'slack-block-msg-kit/BlockElements/DatePickerElement';
+
+const datePicker = new DatePickerElement('ACT001');
+
+datePicker.addConfirmationDialogByParameters(
+  'confirm',
+  new Text(TextType.plainText, 'Are you sure?'),
+  'Yes',
+  'No',
+);
+```
+
+## Possible Errors
+
+| Error | Cause | Remedy |
+| ----- | ----- | ------ |
+| 'actionId should not be more than 255 characters.' | Adding more than 255 characters in the actionId | Reduce the actionId size |
+| 'Year must have four digits' | Trying to add an invalid year | Ensure the year has four digits |
+| 'Month out of range' | Trying to add a month outside the 12 calender months | Ensure the month is within the range of 1 - 12 |
+| 'Day out of range' | Trying to add a day outside the bounds of the preselected month | Ensure the date falls within that calender month |
+| 'Only leap years have 29 days in February' | Trying to add 29 of February in a non leap year | Ensure the date falls within that calender month |

--- a/docs/BlockElements/OverflowMenuElement.md
+++ b/docs/BlockElements/OverflowMenuElement.md
@@ -57,6 +57,8 @@ overflowMenu.addConfirmationDialogByParameters(
 );
 ```
 
+## Possible Errors
+
 | Error | Cause | Remedy |
 | ----- | ----- | ------ |
 | 'actionId should not be more than 255 characters.' | Adding more than 255 characters in the actionId | Reduce the actionId size |

--- a/src/BlockElements/DatePickerElement.ts
+++ b/src/BlockElements/DatePickerElement.ts
@@ -1,0 +1,121 @@
+import ConfirmationDialog from '../CompositionObjects/ConfirmationDialog';
+import Text, { TextType } from '../CompositionObjects/Text';
+import { Helpers } from '../helpers';
+import BlockElement, { BlockElementType } from './BlockElement';
+
+/**
+ * @description This is the date picker element class.
+ * For more info regarding this, kindly visit https://api.slack.com/reference/messaging/block-elements#datepicker
+ */
+export default class DatePickerElement extends BlockElement {
+  public placeholder?: Text;
+  public initial_date?: string;
+  public confirm?: ConfirmationDialog;
+
+  /**
+   * @description Create a new instance of the date picker class
+   * @param  {string} actionId The action id of this element
+   */
+  constructor(actionId: string) {
+    super(BlockElementType.datePicker, actionId);
+  }
+
+  /**
+   * @description Add a placeholder text
+   * @param  {string} placeholder The placeholder text
+   * @returns DatePickerElement
+   */
+  public addPlaceholder(placeholder: string): DatePickerElement {
+    Helpers.validateString(placeholder, 'placeholder', 150);
+
+    this.placeholder = new Text(TextType.plainText, placeholder);
+    return this;
+  }
+
+  /**
+   * @description Add an initially selected date to the date picker
+   * @param  {number} year The date to be pre selected
+   * @param  {number} month The date to be pre selected
+   * @param  {number} day The date to be pre selected
+   * @returns DatePickerElement
+   */
+  public addInitialDate(year: number, month: number, day: number): DatePickerElement {
+    this.validateRegex(/^[0-9]{4}$/, year.toString(), 'Year must have four digits');
+    this.validateRegex(/(^1[0-2]$)|(^[1-9]{1}$)/, month.toString(), 'Month out of range');
+    this.validateRegex(/(^[1-9]$)|(^[1-2][0-9]?$)|(^3[0-1]$)/, day.toString(), 'Day out of range');
+
+    this.validateDay(year, month, day);
+
+    this.initial_date = `${year}-${month < 10 ? 0 : ''}${month}-${day < 10 ? 0 : ''}${day}`;
+    return this;
+  }
+
+  /**
+   * @description Add a confirmation dialog by providing the parameters that is displayed when an option is selected.
+   * This method will create the confirmation dialog.
+   * @param  {string} dialogTitle The dialog title
+   * @param  {Text} dialogText The message to be displayed in the dialog
+   * @param  {string} confirmButton The confirm button label text
+   * @param  {string} denyButton The deny button text
+   * @returns ButtonElement
+   */
+  public addConfirmationDialogByParameters(
+    dialogTitle: string,
+    dialogText: Text,
+    confirmButton: string,
+    denyButton: string,
+  ): DatePickerElement {
+    this.confirm = new ConfirmationDialog(dialogTitle, dialogText, confirmButton, denyButton);
+
+    return this;
+  }
+
+  /**
+   * @description validate a regular expression
+   * @param  {RegExp} regex The regex pattern
+   * @param  {string} param The parameter to be validated
+   * @param  {string} error The error message to display
+   */
+  private validateRegex(regex: RegExp, param: string, error: string) {
+    if (!regex.test(param)) {
+      throw new Error(error);
+    }
+  }
+
+  /**
+   * @description validate a day in the year
+   * @param  {number} year The year
+   * @param  {number} month The month
+   * @param  {number} day The day
+   */
+  private validateDay(year: number, month: number, day: number) {
+    this.validateLongMonths(day, month);
+    this.validateLeapYear(year, month, day);
+  }
+
+  /**
+   * @description validate last february day in leap year
+   * @param  {number} year The year
+   * @param  {number} month The month
+   * @param  {number} day The day
+   */
+  private validateLeapYear(year: number, month: number, day: number) {
+    const yearDiff = year - 2020;
+
+    if (yearDiff % 4 !== 0 && month === 2 && day === 29) {
+      throw new Error('Only leap years have 29 days in February');
+    }
+  }
+
+  /**
+   * @description Validate last day of long months
+   * @param  {number} day The day
+   * @param  {number} month The month
+   */
+  private validateLongMonths(day: number, month: number) {
+    const longMonths = [1, 3, 5, 7, 8, 10, 12];
+    if (day > 30 && longMonths.indexOf(month) < 0) {
+      throw new Error('Day out of month range');
+    }
+  }
+}

--- a/src/BlockElements/__tests__/DatePickerElement.spec.ts
+++ b/src/BlockElements/__tests__/DatePickerElement.spec.ts
@@ -1,0 +1,126 @@
+import Text, { TextType } from '../../CompositionObjects/Text';
+import DatePickerElement from '../DatePickerElement';
+
+describe('DatePickerElement', () => {
+  it('should create a new date picker object', () => {
+    const datePicker = new DatePickerElement('ACT001');
+
+    expect(datePicker).toEqual({
+      action_id: 'ACT001',
+      type: 'datepicker',
+    });
+  });
+
+  describe('addPlaceholder()', () => {
+    it('should add a placeholder text', () => {
+      const datePicker = new DatePickerElement('ACT001');
+
+      datePicker.addPlaceholder('placeholder');
+
+      expect(datePicker).toEqual({
+        action_id: 'ACT001',
+        placeholder: {
+          text: 'placeholder',
+          type: 'plain_text',
+        },
+        type: 'datepicker',
+      });
+    });
+  });
+
+  describe('addInitialDate()', () => {
+    it('should assign an initial date', () => {
+      const datePicker = new DatePickerElement('ACT001');
+
+      datePicker.addInitialDate(2024, 2, 29);
+
+      expect(datePicker).toEqual({
+        action_id: 'ACT001',
+        initial_date: '2024-02-29',
+        type: 'datepicker',
+      });
+    });
+
+    it('should throw year invalid error', done => {
+      try {
+        const datePicker = new DatePickerElement('ACT001');
+
+        datePicker.addInitialDate(19, 2, 29);
+      } catch (error) {
+        expect(error.message).toEqual('Year must have four digits');
+        done();
+      }
+    });
+
+    it('should throw month invalid error', done => {
+      try {
+        const datePicker = new DatePickerElement('ACT001');
+
+        datePicker.addInitialDate(2019, 13, 29);
+      } catch (error) {
+        expect(error.message).toEqual('Month out of range');
+        done();
+      }
+    });
+
+    it('should throw month invalid error', done => {
+      try {
+        const datePicker = new DatePickerElement('ACT001');
+
+        datePicker.addInitialDate(2019, 12, 33);
+      } catch (error) {
+        expect(error.message).toEqual('Day out of range');
+        done();
+      }
+    });
+
+    it('should throw only leap years can have 29 days in feb', done => {
+      try {
+        const datePicker = new DatePickerElement('ACT001');
+
+        datePicker.addInitialDate(2019, 2, 29);
+      } catch (error) {
+        expect(error.message).toEqual('Only leap years have 29 days in February');
+        done();
+      }
+    });
+
+    it('should throw day out of bound error', done => {
+      try {
+        const datePicker = new DatePickerElement('ACT001');
+
+        datePicker.addInitialDate(2019, 4, 31);
+      } catch (error) {
+        expect(error.message).toEqual('Day out of month range');
+        done();
+      }
+    });
+  });
+
+  describe('addConfirmationDialogByParameters()', () => {
+    it('should add a confirmation dialog', () => {
+      const datePicker = new DatePickerElement('ACT001');
+
+      datePicker.addConfirmationDialogByParameters('Confirm', new Text(TextType.plainText, 'dialog text'), 'Yes', 'No');
+
+      expect(datePicker.confirm).toEqual({
+        confirm: {
+          text: 'Yes',
+          type: 'plain_text',
+        },
+        deny: {
+          text: 'No',
+          type: 'plain_text',
+        },
+        text: {
+          text: 'dialog text',
+          type: 'plain_text',
+        },
+        title: {
+          text: 'Confirm',
+          type: 'plain_text',
+        },
+      });
+    });
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import BlockElement, { BlockElementType } from './BlockElements/BlockElement';
 import ButtonElement, { ButtonStyle } from './BlockElements/ButtonElement';
 import ChannelSelectElement from './BlockElements/ChannelSelectElement';
 import ConversationSelectElement from './BlockElements/ConversationSelectElement';
+import DatePickerElement from './BlockElements/DatePickerElement';
 import ImageElement from './BlockElements/ImageElement';
 import OverflowMenuElement from './BlockElements/OverflowMenuElement';
 import StaticSelectElement from './BlockElements/StaticSelectElement';
@@ -28,6 +29,7 @@ export {
   ConfirmationDialog,
   Context,
   ConversationSelectElement,
+  DatePickerElement,
   Image,
   ImageElement,
   Option,


### PR DESCRIPTION
# Add Date Picker

## What does this PR do

This PR adds the date picker menu class to the library

## Background context

The date picker menu allows users to select a date from a calendar month on slack

## Task completed (detailed list of changes/additions)

- [x] add date picker class
- [x] add date picker test
- [x] add date picker documentation
