### PR TITLE
Add Divider Class

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ This library is still in active development and only the following classes are c
 > - **[Image](https://github.com/IyiKuyoro/slack-block-msg-kit/blob/master/docs/Blocks/ImageBlock.md)**
 > - **[Actions](https://github.com/IyiKuyoro/slack-block-msg-kit/blob/master/docs/Blocks/ActionsBlock.md)**
 > - **[Context](https://github.com/IyiKuyoro/slack-block-msg-kit/blob/master/docs/Blocks/ContextBlock.md)**
+> - **[Divider](https://github.com/IyiKuyoro/slack-block-msg-kit/blob/master/docs/Blocks/Divider.md)**
 
 - [Block Elements](https://github.com/IyiKuyoro/slack-block-msg-kit/blob/master/docs/BlockElements/BlockElements.md)
 

--- a/docs/Blocks/DividerBlock.md
+++ b/docs/Blocks/DividerBlock.md
@@ -1,0 +1,43 @@
+# Divider
+
+A [divider](https://api.slack.com/reference/messaging/blocks#divider) is a fine line that separates two blocks on in a message.
+
+## Table of Content
+
+- [Divider](#Divider)
+  - [Table of Content](#Table-of-Content)
+  - [Importing the Image class](#Importing-the-Image-class)
+  - [Creating a Divider (Constructor)](#Creating-a-Divider-Constructor)
+  - [Possible errors](#Possible-errors)
+
+## Importing the Image class
+
+```javascript
+import Divider from 'slack-block-msg-kit/Blocks/Divider';
+```
+
+or
+
+```javascript
+import { Divider } from 'slack-block-msg-kit';
+```
+
+## Creating a Divider (Constructor)
+
+| Parameter | Type   | Description | Example |
+| --------- | ------ | ----------- | ------- |
+| _blockId_ | string? | A string that is return to your app in the payload to represent this block | 'BLK001' |
+
+You can create a divider with our without a block id. Simply pass the constructor is only parameter to include a block id.
+
+```javascript
+import { Divider } from 'slack-block-msg-kit';
+
+const div = new Divider();
+```
+
+## Possible errors
+
+| Error | Cause | Remedy |
+| ----- | ----- | ------ |
+| 'blockId should not be more than 255 characters.' | Trying to add a block id that is beyond 255 characters | Reduce the block id length. |

--- a/src/Blocks/Divider.ts
+++ b/src/Blocks/Divider.ts
@@ -1,0 +1,15 @@
+import Block, { BlockType } from './Block';
+
+/**
+ * @description This is the divider class.
+ * For more info regarding this, kindly visit https://api.slack.com/reference/messaging/blocks#divider
+ */
+export default class Divider extends Block {
+  /**
+   * @description Create a new instance of the divider class
+   * @param  {string} blockId? The block id
+   */
+  constructor(blockId?: string) {
+    super(BlockType.divider, blockId);
+  }
+}

--- a/src/Blocks/__tests__/Divider.spec.ts
+++ b/src/Blocks/__tests__/Divider.spec.ts
@@ -1,0 +1,20 @@
+import Divider from '../Divider';
+
+describe('Divider', () => {
+  it('should create a divider object with a block id', () => {
+    const divider = new Divider('BLK001');
+
+    expect(divider).toEqual({
+      block_id: 'BLK001',
+      type: 'divider',
+    });
+  });
+
+  it('should create a divider without a block id', () => {
+    const divider = new Divider();
+
+    expect(divider).toEqual({
+      type: 'divider',
+    });
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import UserSelectElement from './BlockElements/UserSelectElement';
 import Actions from './Blocks/Actions';
 import Block, { BlockType } from './Blocks/Block';
 import Context from './Blocks/Context';
+import Divider from './Blocks/Divider';
 import Image from './Blocks/Image';
 import Section from './Blocks/Section';
 import ConfirmationDialog from './CompositionObjects/ConfirmationDialog';
@@ -30,6 +31,7 @@ export {
   Context,
   ConversationSelectElement,
   DatePickerElement,
+  Divider,
   Image,
   ImageElement,
   Option,


### PR DESCRIPTION
# Add Divider Class

## What does this PR do

This PR adds the divider class to the library

## Background context

A divider class creates a fine line of separation between blocks on slack

## Task completed (detailed list of changes/additions)

- [x] add divider class
- [x] add divider test
- [x] add divider docs