### PR TITLE
Add Select Menu Element

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ This library is still in active development and only the following classes are c
 > - **[ConversationSelect](https://github.com/IyiKuyoro/slack-block-msg-kit/blob/master/docs/BlockElements/ConversationSelectElement.md)**
 > - **[ChannelSelect](https://github.com/IyiKuyoro/slack-block-msg-kit/blob/master/docs/BlockElements/ChannelSelectElement.md)**
 > - **[OverflowMenu](https://github.com/IyiKuyoro/slack-block-msg-kit/blob/master/docs/BlockElements/OverflowMenuElement.md)**
-> - **[DatePicker](https://github.com/IyiKuyoro/slack-block-msg-kit/blob/master/docs/BlockElements/DatePickerElement.md)**
 
 - [Composition Objects](https://github.com/IyiKuyoro/slack-block-msg-kit/blob/master/docs/CompositionObjects/CompositionObjects.md)
 
@@ -50,6 +49,7 @@ This library is still in active development and only the following classes are c
 ## Contributors
 
 - [Opeoluwa Iyi-Kuyoro](https://github.com/IyiKuyoro): 👨🏿(Creator)
+- [Akinremi Olumide](https://github.com/akinmyde): 👨🏿(Contributor)
 
 ## How to Contribute
 

--- a/docs/BlockElements/OverflowMenuElement.md
+++ b/docs/BlockElements/OverflowMenuElement.md
@@ -57,8 +57,6 @@ overflowMenu.addConfirmationDialogByParameters(
 );
 ```
 
-## Possible Errors
-
 | Error | Cause | Remedy |
 | ----- | ----- | ------ |
 | 'actionId should not be more than 255 characters.' | Adding more than 255 characters in the actionId | Reduce the actionId size |

--- a/src/BlockElements/ExternalSelectElement.ts
+++ b/src/BlockElements/ExternalSelectElement.ts
@@ -1,0 +1,44 @@
+import SelectElement from "./SelectElement";
+import { BlockElementType } from './BlockElement';
+import Option from "../CompositionObjects/Option";
+
+/**
+ * @description This is the base class for external data source like static select.
+ * For more info regarding select elements, kindly visit https://api.slack.com/reference/messaging/block-elements#external-select
+ */
+export default class ExternalSelectElement extends SelectElement {
+  public initial_option?: Option;
+  public min_query_length?: Number;
+
+    /**
+   * @description Create a new instance of a select element.
+   * @param  {string} placeholder The select element placeholder
+   * @param  {string} actionId The action id for the select element
+   */
+  constructor(actionId: string, placeholder: string) {
+    super(BlockElementType.selectExternal, actionId, placeholder);
+  }
+
+  /**
+   * @description Add Initial option to the External select class element
+   * @param {Option} initial_option select option
+   * @returns UserSelectElement
+   */
+  public addInitialOption(initialOption: Option): ExternalSelectElement {
+    this.initial_option = initialOption;
+    return this;
+  }
+
+  /**
+   * @description Add min_query_length to the External select class element
+   * @param {number} minQueryLength The length of the min query
+   * @returns UserSelectElement
+   */
+  public addMinQueryLength(minQueryLength: number): ExternalSelectElement {
+    if (minQueryLength <= 0) {
+      throw new Error('minQueryLength should be greater than 0.');
+    }
+    this.min_query_length = minQueryLength;
+    return this;
+  }
+}

--- a/src/BlockElements/__tests__/ExternalSelectElement.spec.ts
+++ b/src/BlockElements/__tests__/ExternalSelectElement.spec.ts
@@ -1,0 +1,50 @@
+import ExternalSelectElement from '../ExternalSelectElement';
+
+describe('ExternalSelectElement', () => {
+  it('should create a new external select element', () => {
+    const externalSelectElement = new ExternalSelectElement('ACT001', 'placeholder');
+    expect(externalSelectElement).toEqual({
+      action_id: 'ACT001',
+      placeholder: {
+        text: 'placeholder',
+        type: 'plain_text',
+      },
+      type: 'external_select',
+    })
+  })
+
+  it('should test addMinQueryLength function', () => {
+    const externalSelectElement = new ExternalSelectElement('ACT001', 'placeholder');
+    externalSelectElement.addMinQueryLength(3)
+    expect(externalSelectElement).toEqual({
+      action_id: 'ACT001',
+      placeholder: {
+        text: 'placeholder',
+        type: 'plain_text',
+      },
+      type: 'external_select',
+      min_query_length: 3
+    })
+    expect(() => externalSelectElement.addMinQueryLength(0)).toThrowError('minQueryLength should be greater than 0.')
+  })
+
+  it('should add addInitialOption', () => {
+    const externalSelectElement = new ExternalSelectElement('ACT001', 'placeholder');
+    externalSelectElement.addInitialOption({
+      text: { type: 'plain_text', text: 'text' },
+      value: 'value'
+    })
+    expect(externalSelectElement).toEqual({
+      action_id: 'ACT001',
+      placeholder: {
+        text: 'placeholder',
+        type: 'plain_text',
+      },
+      type: 'external_select',
+      initial_option: {
+        text: { type: 'mrkdwn', text: 'text' },
+        value: 'value'
+      }
+    })
+  })
+})


### PR DESCRIPTION
# Add External Select Menu Element

## What does this PR do
This PR adds the External Select Menu Option class

## Background context

The ExternalSelectElement helps render Select menu with an external data source

## Task completed (detailed list of changes/additions)

- [x] add ExternalSelectElement class
- [x] write test