### PR TITLE
Add External Select Menu Element

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ This library is still in active development and only the following classes are c
 > - **[Image](https://github.com/IyiKuyoro/slack-block-msg-kit/blob/master/docs/BlockElements/ImageElement.md)**
 > - **[Button](https://github.com/IyiKuyoro/slack-block-msg-kit/blob/master/docs/BlockElements/ButtonElement.md)**
 > - **[StaticSelect](https://github.com/IyiKuyoro/slack-block-msg-kit/blob/master/docs/BlockElements/StaticSelectElement.md)**
+> - **[ExternalSelect](https://github.com/IyiKuyoro/slack-block-msg-kit/blob/master/docs/BlockElements/ExternalSelectElement.md)**
 > - **[UserSelect](https://github.com/IyiKuyoro/slack-block-msg-kit/blob/master/docs/BlockElements/UserSelectElement.md)**
 > - **[ConversationSelect](https://github.com/IyiKuyoro/slack-block-msg-kit/blob/master/docs/BlockElements/ConversationSelectElement.md)**
 > - **[ChannelSelect](https://github.com/IyiKuyoro/slack-block-msg-kit/blob/master/docs/BlockElements/ChannelSelectElement.md)**

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ This library is still in active development and only the following classes are c
 ## Contributors
 
 - [Opeoluwa Iyi-Kuyoro](https://github.com/IyiKuyoro): 👨🏿(Creator)
+- [Akinremi Olumide](https://github.com/akinmyde): 👨🏿(Contributor)
 
 ## How to Contribute
 

--- a/docs/BlockElements/ExternalSelectElement.md
+++ b/docs/BlockElements/ExternalSelectElement.md
@@ -1,0 +1,97 @@
+# External Select
+
+[External select](https://api.slack.com/reference/messaging/block-elements#external-select) renders a select menu from an external list of options.
+
+## Table of Content
+
+- [External Select](#External-Select)
+  - [Table of Content](#Table-of-Content)
+  - [Importing the ExternalSelectElement Class](#Importing-the-ExternalSelectElement-Class)
+  - [Creating an External Select Element Object (Constructor)](#Creating-an-External-Select-Element-Object-Constructor)
+  - [Adding an initial option (addInitialOption)](#Adding-an-initial-option-addInitialOption)
+  - [Adding a Minimum Query Length (addMinQueryLength())](#Adding-a-Minimum-Query-Length-addMinQueryLength)
+  - [Adding a confirmation dialog (addConfirmationDialogByParameters())](#Adding-a-confirmation-dialog-addConfirmationDialogByParameters)
+  - [Possible Errors](#Possible-Errors)
+
+## Importing the ExternalSelectElement Class
+
+```javascript
+import { ExternalSelectElement } from 'slack-block-msg-kit';
+```
+
+or
+
+```javascript
+import ExternalSelectElement from 'slack-block-msg-kit/BlockElements/ExternalSelectElement';
+```
+
+## Creating an External Select Element Object (Constructor)
+
+| Parameter | Type | Description | Example |
+| --------- | ---- | ----------- | ------- |
+| actionId  | string | The action id of the select element | 'ACT001' |
+| placeholder | string | The placeholder text for the select element | 'select an option' |
+
+```javascript
+import ExternalSelectElement from 'slack-block-msg-kit/BlockElements/ExternalSelectElement';
+
+const sel = new ExternalSelectElement('ACT001', 'select an option');
+```
+
+## Adding an initial option (addInitialOption)
+
+An initial option can be selected by default when the select menu is loaded. It is one of the optional parameters that can be added to the external select object. To add the initial_option property, simply make use of the **addInitialOption** method.
+
+| Parameter | Type | Description | Example |
+| --------- | ---- | ----------- | ------- |
+| initialOption | Option | 'The initial option to be selected when the menu is loaded' | new Option('Option 1', 'value 1') |
+
+```javascript
+import ExternalSelectElement from 'slack-block-msg-kit/BlockElements/ExternalSelectElement';
+import Option from 'slack-block-msg-kit/CompositionObjects/Option';
+
+const sel = new ExternalSelectElement('ACT001', 'select an option');
+
+sel.addInitialOption(new Option('Option 1', 'value 1'));
+```
+
+## Adding a Minimum Query Length (addMinQueryLength())
+
+The min_query_length can be used to limit the amount of request made to your server to load the options when the typeahead field is used.
+
+| Parameter | Type | Description | Example |
+| --------- | ---- | ----------- | ------- |
+| minQueryLength | number | Fewest number of typed characters required to initiate a request | 4 |
+
+```javascript
+import ExternalSelectElement from 'slack-block-msg-kit/BlockElements/ExternalSelectElement';
+
+const sel = new ExternalSelectElement('ACT001', 'select an option');
+
+sel.addMinQueryLength(3);
+```
+
+## Adding a confirmation dialog (addConfirmationDialogByParameters())
+
+You may wish to confirm the user selection with a [Confirmation Dialog](https://github.com/IyiKuyoro/slack-block-msg-kit/blob/master/docs/CompositionObjects/ConfirmationDialog.md). Simply make use of the (**addConfirmationDialogByParameters**) method for this.
+
+```javascript
+import ExternalSelectElement from 'slack-block-msg-kit/BlockElements/ExternalSelectElement';
+import { Text, TextType } from 'slack-block-msg-kit';
+
+const sel = new ExternalSelectElement('ACT001', 'select an option');
+
+sel.addConfirmationDialogByParameters(
+  'Dialog title',
+  new Text(TextType.plainText, 'Dialog message'),
+  'Yes',
+  'No',
+);
+```
+
+## Possible Errors
+
+| Error | Cause | Remedy |
+| ----- | ----- | ------ |
+| 'placeholder should not be more than 150 characters.' | Adding more than 150 characters in the placeholder | Reduce the placeholder size |
+| 'actionId should not be more than 255 characters.' | Adding more than 255 characters in the actionId | Reduce the actionId size |

--- a/src/BlockElements/ExternalSelectElement.ts
+++ b/src/BlockElements/ExternalSelectElement.ts
@@ -3,7 +3,7 @@ import { BlockElementType } from './BlockElement';
 import SelectElement from './SelectElement';
 
 /**
- * @description This is the base class for external data source like static select.
+ * @description This is the class for external data source like static select.
  * For more info regarding select elements, kindly visit https://api.slack.com/reference/messaging/block-elements#external-select
  */
 export default class ExternalSelectElement extends SelectElement {

--- a/src/BlockElements/ExternalSelectElement.ts
+++ b/src/BlockElements/ExternalSelectElement.ts
@@ -1,0 +1,44 @@
+import Option from '../CompositionObjects/Option';
+import { BlockElementType } from './BlockElement';
+import SelectElement from './SelectElement';
+
+/**
+ * @description This is the base class for external data source like static select.
+ * For more info regarding select elements, kindly visit https://api.slack.com/reference/messaging/block-elements#external-select
+ */
+export default class ExternalSelectElement extends SelectElement {
+  public initial_option?: Option;
+  public min_query_length?: number;
+
+  /**
+   * @description Create a new instance of a select element.
+   * @param  {string} placeholder The select element placeholder
+   * @param  {string} actionId The action id for the select element
+   */
+  constructor(actionId: string, placeholder: string) {
+    super(BlockElementType.selectExternal, actionId, placeholder);
+  }
+
+  /**
+   * @description Add Initial option to the External select class element
+   * @param {Option} initial_option select option
+   * @returns UserSelectElement
+   */
+  public addInitialOption(initialOption: Option): ExternalSelectElement {
+    this.initial_option = initialOption;
+    return this;
+  }
+
+  /**
+   * @description Add min_query_length to the External select class element
+   * @param {number} minQueryLength The length of the min query
+   * @returns UserSelectElement
+   */
+  public addMinQueryLength(minQueryLength: number): ExternalSelectElement {
+    if (minQueryLength <= 0) {
+      throw new Error('minQueryLength should be greater than 0.');
+    }
+    this.min_query_length = minQueryLength;
+    return this;
+  }
+}

--- a/src/BlockElements/__tests__/ExternalSelectElement.spec.ts
+++ b/src/BlockElements/__tests__/ExternalSelectElement.spec.ts
@@ -1,0 +1,48 @@
+import ExternalSelectElement from '../ExternalSelectElement';
+import Option from '../../CompositionObjects/Option';
+
+describe('ExternalSelectElement', () => {
+  it('should create a new external select element', () => {
+    const externalSelectElement = new ExternalSelectElement('ACT001', 'placeholder');
+    expect(externalSelectElement).toEqual({
+      action_id: 'ACT001',
+      placeholder: {
+        text: 'placeholder',
+        type: 'plain_text',
+      },
+      type: 'external_select',
+    });
+  });
+
+  it('should test addMinQueryLength function', () => {
+    const externalSelectElement = new ExternalSelectElement('ACT001', 'placeholder');
+    externalSelectElement.addMinQueryLength(3);
+    expect(externalSelectElement).toEqual({
+      action_id: 'ACT001',
+      placeholder: {
+        text: 'placeholder',
+        type: 'plain_text',
+      },
+      type: 'external_select',
+      min_query_length: 3,
+    });
+    expect(() => externalSelectElement.addMinQueryLength(0)).toThrowError('minQueryLength should be greater than 0.');
+  });
+
+  it('should test addInitialOption function', () => {
+    const externalSelectElement = new ExternalSelectElement('ACT001', 'placeholder');
+    externalSelectElement.addInitialOption(new Option('Option 1', 'Value 1'));
+    expect(externalSelectElement).toEqual({
+      action_id: 'ACT001',
+      placeholder: {
+        type: 'plain_text',
+        text: 'placeholder',
+      },
+      type: 'external_select',
+      initial_option: {
+        text: { type: 'plain_text', text: 'Option 1' },
+        value: 'Value 1',
+      },
+    });
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import ButtonElement, { ButtonStyle } from './BlockElements/ButtonElement';
 import ChannelSelectElement from './BlockElements/ChannelSelectElement';
 import ConversationSelectElement from './BlockElements/ConversationSelectElement';
 import DatePickerElement from './BlockElements/DatePickerElement';
+import ExternalSelectElement from './BlockElements/ExternalSelectElement';
 import ImageElement from './BlockElements/ImageElement';
 import OverflowMenuElement from './BlockElements/OverflowMenuElement';
 import StaticSelectElement from './BlockElements/StaticSelectElement';
@@ -32,6 +33,7 @@ export {
   ConversationSelectElement,
   DatePickerElement,
   Divider,
+  ExternalSelectElement,
   Image,
   ImageElement,
   Option,


### PR DESCRIPTION
# Add External Select Menu Element

## What does this PR do
This PR adds the External Select Menu Option class

## Background context

The ExternalSelectElement helps render Select menu with an external data source

## Task completed (detailed list of changes/additions)

- [x] add ExternalSelectElement class
- [x] write test