### PR TITLE
Add Slack Dialog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 /BlockElements
 /CompositionObjects
 /InteractiveMessage
+/FeatureElements
 /helpers
 /index.d.ts
 /index.js

--- a/README.md
+++ b/README.md
@@ -6,11 +6,12 @@ This is a simple library that helps build slack block messages and all it's elem
 
 ## Table of Content
 
-- [Slack Block Message Kit](#Slack-Block-Message-Kit)
-  - [Table of Content](#Table-of-Content)
-  - [How to Use](#How-to-Use)
-  - [Contributors](#Contributors)
-  - [How to Contribute](#How-to-Contribute)
+- [Slack Block Message Kit](#slack-block-message-kit)
+  - [Table of Content](#table-of-content)
+  - [How to Use](#how-to-use)
+    - [Slack Dialogs](#slack-dialogs)
+  - [Contributors](#contributors)
+  - [How to Contribute](#how-to-contribute)
 
 ## How to Use
 
@@ -48,6 +49,17 @@ Below is a list of all the available blocks, elements and composition objects to
 > - **[Confirmation Dialog](https://github.com/IyiKuyoro/slack-block-msg-kit/blob/master/docs/CompositionObjects/ConfirmationDialog.md)**
 > - **[Option](https://github.com/IyiKuyoro/slack-block-msg-kit/blob/master/docs/CompositionObjects/Option.md)**
 > - **[OptionGroup](https://github.com/IyiKuyoro/slack-block-msg-kit/blob/master/docs/CompositionObjects/OptionGroup.md)**
+
+### Slack Dialogs
+
+Dialogs are a very convenient way of collecting information on slack. We have included a dialog class together with all supporting element to aid the creation of dialogs and elements in your codebase. Here is a list to the documentation of the dialog and all the elements.
+
+- **[Dialog](https://github.com/IyiKuyoro/slack-block-msg-kit/blob/master/docs/FeatureElements/Dialog.md)**
+- **[DialogTextElement](https://github.com/IyiKuyoro/slack-block-msg-kit/blob/master/docs/FeatureElements/DialogTextElement.md)**
+- **[DialogTextareaElement](https://github.com/IyiKuyoro/slack-block-msg-kit/blob/master/docs/FeatureElements/DialogTextareaElement.md)**
+- **[DialogSelectElement](https://github.com/IyiKuyoro/slack-block-msg-kit/blob/master/docs/FeatureElements/DialogSelectElement.md)**
+- **[DialogSelectOption](https://github.com/IyiKuyoro/slack-block-msg-kit/blob/master/docs/FeatureElements/DialogSelectOption.md)**
+- **[DialogSelectOptionGroup](https://github.com/IyiKuyoro/slack-block-msg-kit/blob/master/docs/FeatureElements/DialogSelectOptionGroup.md)**
 
 ## Contributors
 

--- a/docs/FeatureElements/Dialog.md
+++ b/docs/FeatureElements/Dialog.md
@@ -1,0 +1,124 @@
+# Dialog
+
+A [slack dialog](https://api.slack.com/dialogs) is a pop up modal that can be used to conveniently collect some information from your user on slack.
+
+## Table of Content
+
+- [Dialog](#dialog)
+  - [Table of Content](#table-of-content)
+  - [Importing the Dialog Class](#importing-the-dialog-class)
+  - [Creating a Dialog (Constructor)](#creating-a-dialog-constructor)
+  - [Adding a state (addState)](#adding-a-state-addstate)
+  - [Change the Submit Button Text (changeSubmitLabel)](#change-the-submit-button-text-changesubmitlabel)
+  - [Notify your app if the dialog is canceled (notifyOnCancel)](#notify-your-app-if-the-dialog-is-canceled-notifyoncancel)
+  - [Possible errors](#possible-errors)
+  - [Dialog Elements](#dialog-elements)
+
+## Importing the Dialog Class
+
+```javascript
+import { Dialog } from 'slack-block-msg-kit';
+```
+
+or
+
+```javascript
+import Dialog from 'slack-block-msg-kit/FeatureElements/Dialog';
+```
+
+## Creating a Dialog (Constructor)
+
+| Parameter | Type | Description | Example |
+| --------- | ---- | ----------- | ------- |
+| title | string | The title of the dialog | 'User Info' |
+| callbackId | string | The callback id of the dialog | 'CLB001' |
+| elements | [DialogElements](#dialog-elements)[] | An array of elements to be added to the dialog | new DialogSelectElement('select label', 'select name') |
+
+```javascript
+import Dialog from 'slack-block-msg-kit/FeatureElements/Dialog';
+
+import DialogSelectOption from 'slack-block-msg-kit/FeatureElements/DialogSelectOption';
+import DialogSelectOptionGroup from 'slack-block-msg-kit/FeatureElements/DialogSelectOptionGroup';
+import DialogSelectElement from 'slack-block-msg-kit/FeatureElements/DialogSelectElement';
+
+const select = new DialogSelectElement('select label', 'select name');
+
+select.addOptionsGroup([
+  new DialogSelectOptionGroup('label', [
+    new DialogSelectOption('label', 'value'),
+    new DialogSelectOption('label1', 'value1'),
+  ])
+]);
+
+const dialog = new Dialog('Dialog Title', 'CLB001', [
+  select
+]);
+```
+
+## Adding a state (addState)
+
+States are a way of passing some data to your app when an action is triggered on slack. Don't use this for secret information, perhaps you should explore the callback id as an option.
+
+| Parameter | Type | Description | Example |
+| --------- | ---- | ----------- | ------- |
+| state | string | The state that you wish to preserve | '{keep: true}' |
+
+```javascript
+...
+
+const dialog = new Dialog('Dialog Title', 'CLB001', [
+  select
+]);
+
+dialog.addState('{keep: true}');
+```
+
+## Change the Submit Button Text (changeSubmitLabel)
+
+The dialog submit button will have a default text of "submit". You can change this to what ever you wish.
+
+| Parameter | Type | Description | Example |
+| --------- | ---- | ----------- | ------- |
+| submitLabel | string | The submit button new text | 'Save' |
+
+```javascript
+...
+
+const dialog = new Dialog('Dialog Title', 'CLB001', [
+  select
+]);
+
+dialog.changeSubmitLabel('Save');
+```
+
+## Notify your app if the dialog is canceled (notifyOnCancel)
+
+You may wish to have your app notified if the dialog is canceled by the user. _No Parameters_
+
+```javascript
+...
+
+const dialog = new Dialog('Dialog Title', 'CLB001', [
+  select
+]);
+
+dialog.notifyOnCancel();
+```
+
+## Possible errors
+
+| Error | Cause | Remedy |
+| ----- | ----- | ------ |
+| 'title should not be more than 24 characters.' | Adding a default title that is more than 24 characters | Reduce the title size |
+| 'callbackId should not be more than 255 characters.' | Adding a default callbackId that is more than 255 characters | Reduce the callbackId size |
+| 'submitLabel should not be more than 48 characters.' | Adding a default submitLabel that is more than 48 characters | Reduce the submitLabel size |
+| 'Cannot have more than 10 elements in a dialog' | Trying to add more than 10 elements to the dialog | Reduce the number of dialog elements |
+| 'You need to add at least one element to the dialog' | Trying to create a dialog with zero element | Add at least one element to your dialog |
+
+## Dialog Elements
+
+Dialog elements are elements that are used in creating input fields on a slack dialog box. There are only three dialog elements. Find the documentations in the link below.
+
+- **[DialogTextElement](https://github.com/IyiKuyoro/slack-block-msg-kit/blob/master/docs/FeatureElements/DialogTextElement.md)**
+- **[DialogTextareaElement](https://github.com/IyiKuyoro/slack-block-msg-kit/blob/master/docs/FeatureElements/DialogTextareaElement.md)**
+- **[DialogSelectElement](https://github.com/IyiKuyoro/slack-block-msg-kit/blob/master/docs/FeatureElements/DialogSelectElement.md)**

--- a/docs/FeatureElements/DialogSelectElement.md
+++ b/docs/FeatureElements/DialogSelectElement.md
@@ -1,0 +1,165 @@
+# DialogSelectElement
+
+[Select elements](https://api.slack.com/dialogs#select_default_values) can be added to slack dialogs. There are several [data sources](#dialogselectdatasource) that can be used for the select menu. The default is static.
+
+## Table of Content
+
+- [DialogSelectElement](#dialogselectelement)
+  - [Table of Content](#table-of-content)
+  - [Importing the DialogSelectElement Class](#importing-the-dialogselectelement-class)
+  - [Create a new Select Element (Constructor)](#create-a-new-select-element-constructor)
+  - [Changing the data source (changeDataSource)](#changing-the-data-source-changedatasource)
+  - [Adding a Minimum Query Length (addMinQueryLength)](#adding-a-minimum-query-length-addminquerylength)
+  - [Adding a default selected option (addSelectedOption)](#adding-a-default-selected-option-addselectedoption)
+  - [Adding Options(addOptions)](#adding-optionsaddoptions)
+  - [Adding Option Group (addOptionsGroup)](#adding-option-group-addoptionsgroup)
+  - [Possible errors](#possible-errors)
+  - [DialogSelectDataSource](#dialogselectdatasource)
+    - [Import DialogSelectDataSource](#import-dialogselectdatasource)
+
+## Importing the DialogSelectElement Class
+
+```javascript
+import DialogSelectElement from 'slack-block-msg-kit/FeatureElements/DialogSelectElement';
+```
+
+or
+
+```javascript
+import { DialogSelectElement } from 'slack-block-msg-kit';
+```
+
+## Create a new Select Element (Constructor)
+
+| Parameter | Type | Description | Example |
+| --------- | ---- | ----------- | ------- |
+| label | string | The fields label | 'Options' |
+| name | string | The name that will be assigned to this field | 'user_options' |
+
+```javascript
+import DialogSelectElement from 'slack-block-msg-kit/FeatureElements/DialogSelectElement';
+
+const select = new DialogSelectElement('select label', 'select name');
+```
+
+## Changing the data source (changeDataSource)
+
+| Parameter | Type | Description | Example |
+| --------- | ---- | ----------- | ------- |
+| newSource | [DialogSelectDataSource](#dialogselectdatasource) | The data source of the select menu | DialogSelectDataSource.external |
+
+```javascript
+import DialogSelectElement, { DialogSelectDataSource } from 'slack-block-msg-kit/FeatureElements/DialogSelectElement';
+
+const select = new DialogSelectElement('select label', 'select name');
+
+select.changeDataSource(DialogSelectDataSource.external);
+```
+
+## Adding a Minimum Query Length (addMinQueryLength)
+
+| Parameter | Type | Description | Example |
+| --------- | ---- | ----------- | ------- |
+| minLength | number | A minimum string length before a request to your app is triggered | 3 |
+
+The minimum query length can only be applied to a select element that has an external data source. It represents the minimum number of characters the user has to type on the on the menu to trigger a request for fresh data.
+
+```javascript
+import DialogSelectElement, { DialogSelectDataSource } from 'slack-block-msg-kit/FeatureElements/DialogSelectElement';
+
+const select = new DialogSelectElement('select label', 'select name');
+
+select
+  .changeDataSource(DialogSelectDataSource.external)
+  .addMinQueryLength(3);
+```
+
+## Adding a default selected option (addSelectedOption)
+
+You may add a default selected option when the menu is loaded for external and static options.
+
+| Parameter | Type | Description | Example |
+| --------- | ---- | ----------- | ------- |
+| options | [DialogSelectOption](https://github.com/IyiKuyoro/slack-block-msg-kit/blob/master/docs/FeatureElements/DialogSelectOption.md) | A default selected option | | new DialogSelectOption('option', 'value') |
+
+```javascript
+import DialogSelectOption from 'slack-block-msg-kit/FeatureElements/DialogSelectOption';
+import DialogSelectElement from 'slack-block-msg-kit/FeatureElements/DialogSelectElement';
+
+const select = new DialogSelectElement('select label', 'select name');
+
+select
+  .addSelectedOption(new DialogSelectOption('option', 'value'));
+```
+
+## Adding Options(addOptions)
+
+Add an array of options to the select menu. Keep in mind that you cannot have option group and options in the same select menu.
+
+| Parameter | Type | Description | Example |
+| --------- | ---- | ----------- | ------- |
+| options | [DialogSelectOption](https://github.com/IyiKuyoro/slack-block-msg-kit/blob/master/docs/FeatureElements/DialogSelectOption.md)[] | An array of options to be added to the select menu | [new DialogSelectOption('label', 'value'), new DialogSelectOption('label1', 'value1')] |
+
+```javascript
+import DialogSelectOption from 'slack-block-msg-kit/FeatureElements/DialogSelectOption';
+import DialogSelectElement from 'slack-block-msg-kit/FeatureElements/DialogSelectElement';
+
+const select = new DialogSelectElement('select label', 'select name');
+
+select.addOptions([
+  new DialogSelectOption('label', 'value'),
+  new DialogSelectOption('label1', 'value1'),
+]);
+```
+
+## Adding Option Group (addOptionsGroup)
+
+Add an array of option groups to the select menu. Keep in mind that you cannot have options and option group in the same select menu.
+
+| Parameter | Type | Description | Example |
+| --------- | ---- | ----------- | ------- |
+| optionGroups | [DialogSelectOptionGroup](https://github.com/IyiKuyoro/slack-block-msg-kit/blob/master/docs/FeatureElements/DialogSelectOptionGroup.md) | An array of option groups | [new DialogSelectOptionGroup('label', [new DialogSelectOption('label', 'value'), new DialogSelectOption('label1', 'value1')])] |
+
+```javascript
+import DialogSelectOption from 'slack-block-msg-kit/FeatureElements/DialogSelectOption';
+import DialogSelectOptionGroup from 'slack-block-msg-kit/FeatureElements/DialogSelectOptionGroup';
+import DialogSelectElement from 'slack-block-msg-kit/FeatureElements/DialogSelectElement';
+
+const select = new DialogSelectElement('select label', 'select name');
+
+select.addOptionsGroup([
+  new DialogSelectOptionGroup('label', [
+    new DialogSelectOption('label', 'value'),
+    new DialogSelectOption('label1', 'value1'),
+  ])
+]);
+```
+
+## Possible errors
+
+| Error | Cause | Remedy |
+| ----- | ----- | ------ |
+| 'label should not be more than 48 characters.` | Adding a label that is more than 48 characters | Reduce the label size |
+| 'name should not be more than 300 characters.` | Adding a name that is more than 300 characters | Reduce the name size |
+| 'Only external data sources require a min query length' | Trying to add min query length to non external data. | Remove the min query |
+| 'minLength must be a positive integer less than 75 and greater than 0` | Providing an invalid minimum length. | Allowable range 0 - 75 |
+| 'Cannot have options and option_groups in the same select menu' | Cannot have options and option_group in the same menu | Chose one format |
+| 'Total options cannot be more than 100' | Trying to add more than 100 options to the select menu | Reduce the number of options or use groups |
+| 'Cannot have more than 100 option groups' | Trying to add more than 100 option groups | Perhaps try to simplify by using an external select |
+
+## DialogSelectDataSource
+
+A select menu can have other data sources different from static. This enum holds all the other permitted data source.
+
+- **users**: Create a select menu with members of the workspace as options
+- **channels**: Create a select menu with channels in the workspace
+- **conversations**: Create a select menu with conversations
+- **external**: Create a select menu with an external data source
+
+### Import DialogSelectDataSource
+
+```javascript
+import { DialogSelectDataSource } from 'slack-block-msg-kit/FeatureElements/DialogSelectElement';
+```
+
+[Here](#changing-the-data-source-changedatasource) are instructions on how to change the data type.

--- a/docs/FeatureElements/DialogSelectOption.md
+++ b/docs/FeatureElements/DialogSelectOption.md
@@ -1,0 +1,37 @@
+# DialogSelectOption
+
+The dialog select option is used to create a single option in a select element on a dialog box.
+
+## Table of Content
+
+- [DialogSelectOption](#dialogselectoption)
+  - [Table of Content](#table-of-content)
+  - [Importing the DialogSelectOption](#importing-the-dialogselectoption)
+  - [creating an Option (Constructor)](#creating-an-option-constructor)
+  - [Possible errors](#possible-errors)
+
+## Importing the DialogSelectOption
+
+```javascript
+import DialogSelectOption from 'slack-block-msg-kit/FeatureElements/DialogSelectOption';
+```
+
+## Creating an Option (Constructor)
+
+| Parameter | Type | Description | Example |
+| --------- | ---- | ----------- | ------- |
+| label | string | The option label | 'Option 1' |
+| value | string | The the value of the option | 'value 1' |
+
+```javascript
+import DialogSelectOption from 'slack-block-msg-kit/FeatureElements/DialogSelectOption';
+
+const opt = new DialogSelectOption('label', 'value');
+```
+
+## Possible errors
+
+| Error | Cause | Remedy |
+| ----- | ----- | ------ |
+| 'label should not be more than 75 characters.` | Adding a default label that is more than 75 characters | Reduce the label size |
+| 'value should not be more than 75 characters.` | Adding a default value that is more than 75 characters | Reduce the value size |

--- a/docs/FeatureElements/DialogSelectOptionGroup.md
+++ b/docs/FeatureElements/DialogSelectOptionGroup.md
@@ -1,0 +1,29 @@
+# DialogSelectOptionGroup
+
+This element groups options together under a label in the select menu.
+
+## Table of Content
+
+- [DialogSelectOptionGroup](#dialogselectoptiongroup)
+  - [Table of Content](#table-of-content)
+  - [Importing the DialogSelectOptionGroup](#importing-the-dialogselectoptiongroup)
+  - [Creating an Option Group (Constructor)](#creating-an-option-group-constructor)
+
+## Importing the DialogSelectOptionGroup
+
+```javascript
+import DialogSelectOptionGroup from 'slack-block-msg-kit/FeatureElements/DialogSelectOptionGroup';
+```
+
+## Creating an Option Group (Constructor)
+
+| Parameter | Type | Description | Example |
+| --------- | ---- | ----------- | ------- |
+| label | string | The option group label | 'Group 1' |
+| options | [DialogSelectOption](https://github.com/IyiKuyoro/slack-block-msg-kit/blob/master/docs/FeatureElements/DialogSelectOption.md)[] | An array of options to be added to this group | [new DialogSelectOption('label', 'value'), new DialogSelectOption('label1', 'value1')] |
+
+| Error | Cause | Remedy |
+| ----- | ----- | ------ |
+| 'label should not be more than 75 characters.` | Adding a default label that is more than 75 characters | Reduce the label size |
+| 'A group cannot have more than 100 options' | Adding a more than 100 options to one group | Reduce the number of options |
+| 'Two options cannot share the same value in one group:...' | Two options should not have the same value | Use different values for different options |

--- a/docs/FeatureElements/DialogTextElement.md
+++ b/docs/FeatureElements/DialogTextElement.md
@@ -1,0 +1,151 @@
+# DialogTextElement
+
+The dialog [text element](https://api.slack.com/dialogs#text_elements) represents the text input fields in a slack dialog box. It is used to create an input field of not more than 150 characters in a dialog.
+
+## Table of Content
+
+- [DialogTextElement](#dialogtextelement)
+  - [Table of Content](#table-of-content)
+  - [Importing the DialogTextElement](#importing-the-dialogtextelement)
+  - [Creating a Text field (Constructor)](#creating-a-text-field-constructor)
+  - [Assign a Max Input Length (assignMaxLength)](#assign-a-max-input-length-assignmaxlength)
+  - [Assign a Min Input Length (assignMinLength)](#assign-a-min-input-length-assignminlength)
+  - [Assign a Hint to the Text (addHint)](#assign-a-hint-to-the-text-addhint)
+  - [Add a Sub Type to the Field (addTextSubType)](#add-a-sub-type-to-the-field-addtextsubtype)
+  - [Setting a Default Value (setDefaultValue)](#setting-a-default-value-setdefaultvalue)
+  - [Possible errors](#possible-errors)
+  - [DialogTextSubType](#dialogtextsubtype)
+    - [Supported Subtypes](#supported-subtypes)
+
+## Importing the DialogTextElement
+
+```javascript
+import DialogTextElement from 'slack-block-msg-kit/FeatureElements/DialogTextElement';
+```
+
+or
+
+```javascript
+import { DialogTextElement } from 'slack-block-msg-kit';
+```
+
+## Creating a Text field (Constructor)
+
+| Parameter | Type | Description | Example |
+| --------- | ---- | ----------- | ------- |
+| label | string | The fields label | 'Name' |
+| name | string | The name that will be assigned to this field | 'user_name' |
+
+Simply pass the text label and name to the DialogTextElement constructor to create a text element
+
+```javascript
+import { DialogTextElement } from 'slack-block-msg-kit';
+
+const text = new DialogTextElement('label', 'name');
+```
+
+## Assign a Max Input Length (assignMaxLength)
+
+| Parameter | Type | Description | Example |
+| --------- | ---- | ----------- | ------- |
+| maxLength | number | The maximum length of characters you wish this text input to have. | 10 |
+
+You may wish to restrict the user to a maximum length of characters in the input field. If this is not set, slack will accept up to 150 characters from the user.
+
+```javascript
+import DialogTextElement from 'slack-block-msg-kit/FeatureElements/DialogTextElement';
+
+const text = new DialogTextElement('label', 'name');
+
+text.assignMaxLength(10);
+```
+
+## Assign a Min Input Length (assignMinLength)
+
+| Parameter | Type | Description | Example |
+| --------- | ---- | ----------- | ------- |
+| minLength | number | The minimum length of characters. | 5 |
+
+You may also wish to set a minium length of required characters to this element.
+
+```javascript
+import DialogTextElement from 'slack-block-msg-kit/FeatureElements/DialogTextElement';
+
+const text = new DialogTextElement('label', 'name');
+
+text.assignMinLength(10);
+```
+
+## Assign a Hint to the Text (addHint)
+
+| Parameter | Type | Description | Example |
+| --------- | ---- | ----------- | ------- |
+| hint | string | The text input hint | 'A little hint for the user.' |
+
+Add a hint for the user.
+
+```javascript
+import DialogTextElement from 'slack-block-msg-kit/FeatureElements/DialogTextElement';
+
+const text = new DialogTextElement('label', 'name');
+
+text.addHint('A user hint.');
+```
+
+## Add a Sub Type to the Field (addTextSubType)
+
+| Parameter | Type | Description | Example |
+| --------- | ---- | ----------- | ------- |
+| type | [DialogTextSubTypes](#dialogtextsubtype) | The subtype of the text element | DialogTextSubTypes.email |
+
+Sometimes, you may want the user to provide a certain kind of text in the input fields. perhaps an email. This is done by adding a subtype to the text element.
+
+```javascript
+import DialogTextElement, { DialogTextSubTypes } from 'slack-block-msg-kit/FeatureElements/DialogTextElement';
+
+const text = new DialogTextElement('label', 'name');
+
+text.addTextSubType(DialogTextSubTypes.email);
+```
+
+## Setting a Default Value (setDefaultValue)
+
+| Parameter | Type | Description | Example |
+| --------- | ---- | ----------- | ------- |
+| value | string | A default value that is preset when the input field is loaded. | 'John Doe' |
+
+```javascript
+import DialogTextElement from 'slack-block-msg-kit/FeatureElements/DialogTextElement';
+
+const text = new DialogTextElement('label', 'name');
+
+text.setDefaultValue('John Doe');
+```
+
+## Possible errors
+
+| Error | Cause | Remedy |
+| ----- | ----- | ------ |
+| 'label should not be more than 48 characters.` | Adding a label that is more than 48 characters | Reduce the label size |
+| 'name should not be more than 300 characters.` | Adding a name that is more than 300 characters | Reduce the name size |
+| 'maxLength must be a positive integer less than 150 and greater than 1` | Providing an invalid max length. | Allowable range 0 - 150 |
+| 'minLength must be a positive integer less than 150 and greater than 1` | Providing an invalid minimum length. | Allowable range 1 - 150 |
+| 'hint should not be more than 150 characters.` | Adding a hint that is more than 150 characters | Reduce the hint size |
+| 'value should not be more than 150 characters.` | Adding a default value that is more than 150 characters | Reduce the value size |
+
+## DialogTextSubType
+
+There is a list of supported subtypes that a text field could have.
+
+```javascript
+import { DialogTextSubTypes } from 'slack-block-msg-kit/FeatureElements/DialogTextElement';
+```
+
+### Supported Subtypes
+
+- email
+- number
+- tel
+- url
+
+Here instructions on changing the subtype for [Text](#add-a-sub-type-to-the-field-addtextsubtype) and [Textarea](https://github.com/IyiKuyoro/slack-block-msg-kit/blob/master/docs/FeatureElements/DialogTextareaElement.md#add-a-sub-type-to-the-field-addtextsubtype)

--- a/docs/FeatureElements/DialogTextareaElement.md
+++ b/docs/FeatureElements/DialogTextareaElement.md
@@ -1,0 +1,131 @@
+# DialogTextareaElement
+
+The dialog [textarea element](https://api.slack.com/dialogs#attributes_textarea_elements) represents an input text area on the slack dialog box. The text area can take up to 3000 characters.
+
+## Table of Content
+
+- [DialogTextareaElement](#dialogtextareaelement)
+  - [Table of Content](#table-of-content)
+  - [Importing the DialogTextareaElement](#importing-the-dialogtextareaelement)
+  - [Creating a Textarea field (Constructor)](#creating-a-textarea-field-constructor)
+  - [Assign a Max Input Length (assignMaxLength)](#assign-a-max-input-length-assignmaxlength)
+  - [Assign a Min Input Length (assignMinLength)](#assign-a-min-input-length-assignminlength)
+  - [Assign a Hint to the Textarea (addHint)](#assign-a-hint-to-the-textarea-addhint)
+  - [Add a Sub Type to the Field (addTextSubType)](#add-a-sub-type-to-the-field-addtextsubtype)
+  - [Setting a Default Value (setDefaultValue)](#setting-a-default-value-setdefaultvalue)
+  - [Possible errors](#possible-errors)
+
+## Importing the DialogTextareaElement
+
+```javascript
+import { DialogTextareaElement } from 'slack-block-msg-kit';
+```
+
+or
+
+```javascript
+import DialogTextareaElement from 'slack-block-msg-kit/FeatureElements/DialogTextareaElement';
+```
+
+## Creating a Textarea field (Constructor)
+
+| Parameter | Type | Description | Example |
+| --------- | ---- | ----------- | ------- |
+| label | string | The fields label | 'Name' |
+| name | string | The name that will be assigned to this field | 'user_name' |
+
+```javascript
+import DialogTextareaElement from 'slack-block-msg-kit/FeatureElements/DialogTextareaElement';
+
+const text = new DialogTextareaElement('label', 'name');
+```
+
+## Assign a Max Input Length (assignMaxLength)
+
+| Parameter | Type | Description | Example |
+| --------- | ---- | ----------- | ------- |
+| maxLength | number | The maximum length of characters you wish this text input to have. | 10 |
+
+You may wish to restrict the user to a maximum length of characters in the input field. If this is not set, slack will accept up to 3000 characters from the user.
+
+```javascript
+import DialogTextareaElement from 'slack-block-msg-kit/FeatureElements/DialogTextareaElement';
+
+const text = new DialogTextareaElement('label', 'name');
+
+text.assignMaxLength(10);
+```
+
+## Assign a Min Input Length (assignMinLength)
+
+| Parameter | Type | Description | Example |
+| --------- | ---- | ----------- | ------- |
+| minLength | number | The minimum length of characters. | 5 |
+
+You may also wish to set a minium length of required characters to this element.
+
+```javascript
+import DialogTextareaElement from 'slack-block-msg-kit/FeatureElements/DialogTextareaElement';
+
+const text = new DialogTextareaElement('label', 'name');
+
+text.assignMinLength(10);
+```
+
+## Assign a Hint to the Textarea (addHint)
+
+| Parameter | Type | Description | Example |
+| --------- | ---- | ----------- | ------- |
+| hint | string | The text input hint | 'A little hint for the user.' |
+
+Add a hint for the user.
+
+```javascript
+import DialogTextareaElement from 'slack-block-msg-kit/FeatureElements/DialogTextareaElement';
+
+const text = new DialogTextareaElement('label', 'name');
+
+text.addHint('A user hint.');
+```
+
+## Add a Sub Type to the Field (addTextSubType)
+
+| Parameter | Type | Description | Example |
+| --------- | ---- | ----------- | ------- |
+| type | [DialogTextSubTypes](https://github.com/IyiKuyoro/slack-block-msg-kit/blob/master/docs/FeatureElement/DialogTextElement.md#dialogtextsubtype) | The subtype of the text element | DialogTextSubTypes.email |
+
+Sometimes, you may want the user to provide a certain kind of textarea in the input fields. perhaps an email. This is done by adding a subtype to the text element.
+
+```javascript
+import { DialogTextSubTypes } from 'slack-block-msg-kit/FeatureElements/DialogTextElement';
+import DialogTextareaElement from 'slack-block-msg-kit/FeatureElements/DialogTextareaElement';
+
+const text = new DialogTextareaElement('label', 'name');
+
+text.addTextSubType(DialogTextSubTypes.email);
+```
+
+## Setting a Default Value (setDefaultValue)
+
+| Parameter | Type | Description | Example |
+| --------- | ---- | ----------- | ------- |
+| value | string | A default value that is preset when the input field is loaded. | 'John Doe' |
+
+```javascript
+import DialogTextareaElement from 'slack-block-msg-kit/FeatureElements/DialogTextareaElement';
+
+const text = new DialogTextareaElement('label', 'name');
+
+text.setDefaultValue('John Doe');
+```
+
+## Possible errors
+
+| Error | Cause | Remedy |
+| ----- | ----- | ------ |
+| 'label should not be more than 48 characters.` | Adding a label that is more than 48 characters | Reduce the label size |
+| 'name should not be more than 300 characters.` | Adding a name that is more than 300 characters | Reduce the name size |
+| 'maxLength must be a positive integer less than 150 and greater than 1` | Providing an invalid max length. | Allowable range 0 - 3000 |
+| 'minLength must be a positive integer less than 150 and greater than 1` | Providing an invalid minimum length. | Allowable range 1 - 30000 |
+| 'hint should not be more than 150 characters.` | Adding a hint that is more than 150 characters | Reduce the hint size |
+| 'value should not be more than 150 characters.` | Adding a default value that is more than 150 characters | Reduce the value size |

--- a/package.json
+++ b/package.json
@@ -9,13 +9,14 @@
     "BlockElements",
     "CompositionObjects",
     "InteractiveMessage",
+    "FeatureElements",
     "helpers",
     "index.d.ts",
     "index.js",
     "README.md"
   ],
   "scripts": {
-    "clear": "rm -rf dist",
+    "clear": "rm -rf BlockElements Blocks CompositionObjects FeatureElements helpers InteractiveMessage",
     "prepare": "npm run clear && npm run build",
     "prepublishOnly": "npm run lint",
     "version": "npm run format && git add -A src",

--- a/src/FeatureElements/Dialog.ts
+++ b/src/FeatureElements/Dialog.ts
@@ -1,0 +1,65 @@
+import { Helpers } from '../helpers';
+import DialogElement from './DialogElement';
+
+/** This class represents a Slack Dialog.
+ *  For more info kindly visit https://api.slack.com/dialogs
+ */
+export default class Dialog {
+  public title: string;
+  public callback_id: string;
+  public elements: DialogElement[];
+  public state?: string;
+  public submit_label?: string;
+  public notify_on_cancel?: boolean;
+
+  /**
+   * @description Create a new instance of a slack dialog
+   * @param  {string} title The title of the dialog
+   * @param  {string} callbackId The call back id of the dialog actions
+   * @param  {DialogElement[]} elements The dialog elements to be added in the dialog
+   */
+  constructor(title: string, callbackId: string, elements: DialogElement[]) {
+    Helpers.validateString(title, 'title', 24);
+    Helpers.validateString(callbackId, 'callbackId', 255);
+    Helpers.validateArrayLength(elements, 10, 'Cannot have more than 10 elements in a dialog');
+
+    if (elements.length <= 0) {
+      throw Error('You need to add at least one element to the dialog');
+    }
+
+    this.title = title;
+    this.callback_id = callbackId;
+    this.elements = elements;
+  }
+
+  /**
+   * @description Add a state string to the dialog
+   * @param  {string} state A string that will be sent back to your app when the dialog is submitted
+   * @returns Dialog
+   */
+  public addState(state: string): Dialog {
+    this.state = state;
+    return this;
+  }
+
+  /**
+   * @description Change the submit button text from the default
+   * @param  {string} submitLabel
+   * @returns Dialog
+   */
+  public changeSubmitLabel(submitLabel: string): Dialog {
+    Helpers.validateString(submitLabel, 'submitLabel', 48);
+
+    this.submit_label = submitLabel;
+    return this;
+  }
+
+  /**
+   * @description Opt to have your app notified when if the user cancels the dialog
+   * @returns Dialog
+   */
+  public notifyOnCancel(): Dialog {
+    this.notify_on_cancel = true;
+    return this;
+  }
+}

--- a/src/FeatureElements/DialogElement.ts
+++ b/src/FeatureElements/DialogElement.ts
@@ -1,0 +1,52 @@
+import { Helpers } from '../helpers';
+
+export enum DialogElementType {
+  text = 'text',
+  textarea = 'textarea',
+  select = 'select',
+}
+
+export default abstract class DialogElement {
+  public label: string;
+  public name: string;
+  public type: DialogElementType;
+  public placeholder?: string;
+  public optional?: boolean;
+  public value?: string;
+
+  /**
+   * @description Create a new instance of the Dialog Element
+   * @param  {string} label The elements label
+   * @param  {string} name The name of the element
+   * @param  {DialogElementType} type The type of the element
+   */
+  constructor(label: string, name: string, type: DialogElementType) {
+    Helpers.validateString(label, 'label', 48);
+    Helpers.validateString(name, 'name', 300);
+
+    this.label = label;
+    this.name = name;
+    this.type = type;
+  }
+
+  /**
+   * @description Add a placeholder to the dialog element
+   * @param  {string} placeholder The string to be used as placeholder
+   * @returns DialogElement
+   */
+  public addPlaceholder(placeholder: string): DialogElement {
+    Helpers.validateString(placeholder, 'placeholder', 150);
+
+    this.placeholder = placeholder;
+    return this;
+  }
+
+  /**
+   * @description Make this field optional
+   * @returns DialogElement
+   */
+  public makeFieldOptional(): DialogElement {
+    this.optional = true;
+    return this;
+  }
+}

--- a/src/FeatureElements/DialogSelectElement.ts
+++ b/src/FeatureElements/DialogSelectElement.ts
@@ -1,0 +1,116 @@
+import { Helpers } from '../helpers';
+import DialogElement, { DialogElementType } from './DialogElement';
+import DialogSelectOption from './DialogSelectOption';
+import DialogSelectOptionGroup from './DialogSelectOptionGroup';
+
+export enum DialogSelectDataSource {
+  users = 'users',
+  channels = 'channels',
+  conversations = 'conversations',
+  external = 'external',
+}
+
+/** This class represents a select field of a slack dialog.
+ *  For more info kindly visit https://api.slack.com/dialogs#dynamic_select_elements
+ */
+export default class DialogSelectElement extends DialogElement {
+  public data_source?: DialogSelectDataSource;
+  public min_query_length?: number;
+  public selected_options?: DialogSelectOption;
+  public options?: DialogSelectOption[];
+  public option_groups?: DialogSelectOptionGroup[];
+
+  /**
+   * @description Constructs a new instance of the DialogSelectElement
+   * @param  {string} label The label of the field
+   * @param  {string} name The name of the field
+   */
+  constructor(label: string, name: string) {
+    super(label, name, DialogElementType.select);
+  }
+
+  /**
+   * @description Change the data source from static
+   * @param  {DialogSelectDataSource} newSource The new data source
+   * @returns DialogSelectElement
+   */
+  public changeDataSource(newSource: DialogSelectDataSource): DialogSelectElement {
+    this.data_source = newSource;
+    return this;
+  }
+
+  /**
+   * @description Change add a min query length to an external data source
+   * @param  {number} minLength The minimum string length before your app is queried for the data
+   * @returns DialogSelectElement
+   */
+  public addMinQueryLength(minLength: number): DialogSelectElement {
+    if (this.data_source !== DialogSelectDataSource.external) {
+      throw new Error('Only external data sources require a min query length');
+    }
+
+    Helpers.validateNumber('minLength', minLength, 75, 0);
+    this.min_query_length = minLength;
+    return this;
+  }
+
+  /**
+   * @description Add a selected option to be used as the default selected option when the menu is loaded
+   * @param  {DialogSelectOption} option The default selected option
+   * @returns DialogSelectElement
+   */
+  public addSelectedOption(option: DialogSelectOption): DialogSelectElement {
+    this.selected_options = option;
+
+    return this;
+  }
+
+  /**
+   * @description Add options to the select menu
+   * @param  {DialogSelectOption[]} options An array of options to be added
+   * @returns DialogSelectElement
+   */
+  public addOptions(options: DialogSelectOption[]): DialogSelectElement {
+    if (this.option_groups) {
+      throw new Error('Cannot have options and option_groups in the same select menu');
+    }
+
+    if (!this.options) {
+      Helpers.validateArrayLength(options, 100, 'Total options cannot be more than 100');
+      Helpers.validateOptions(options);
+      this.options = options;
+    } else {
+      const totOpt = [...this.options, ...options];
+      Helpers.validateArrayLength(totOpt, 100, 'Total options cannot be more than 100');
+      Helpers.validateOptions(totOpt);
+      this.options.push(...options);
+    }
+
+    return this;
+  }
+
+  /**
+   * @description Add a list of option groups to the menu
+   * @param  {DialogSelectOptionGroup[]} optionGroups An array of option groups
+   * @returns DialogSelectElement
+   */
+  public addOptionsGroup(optionGroups: DialogSelectOptionGroup[]): DialogSelectElement {
+    if (this.options) {
+      throw new Error('Cannot have options and option_groups in the same select menu');
+    }
+
+    if (!this.option_groups) {
+      Helpers.validateArrayLength(optionGroups, 100, 'Cannot have more than 100 option groups');
+      this.option_groups = optionGroups;
+    } else {
+      Helpers.validateArrayLength(
+        [...this.option_groups, ...optionGroups],
+        100,
+        'Cannot have more than 100 option groups',
+      );
+      this.option_groups.push(...optionGroups);
+    }
+
+    return this;
+  }
+}

--- a/src/FeatureElements/DialogSelectOption.ts
+++ b/src/FeatureElements/DialogSelectOption.ts
@@ -1,0 +1,19 @@
+import { Helpers } from '../helpers';
+
+export default class DialogSelectOption {
+  public label: string;
+  public value: string;
+
+  /**
+   * @description Create a new instance of the option class
+   * @param  {string} label The option label
+   * @param  {string} value The option value
+   */
+  constructor(label: string, value: string) {
+    Helpers.validateString(label, 'label', 75);
+    Helpers.validateString(value, 'value', 75);
+
+    this.label = label;
+    this.value = value;
+  }
+}

--- a/src/FeatureElements/DialogSelectOptionGroup.ts
+++ b/src/FeatureElements/DialogSelectOptionGroup.ts
@@ -1,0 +1,21 @@
+import { Helpers } from '../helpers';
+import DialogSelectOption from './DialogSelectOption';
+
+export default class DialogSelectOptionGroup {
+  public label: string;
+  public options: DialogSelectOption[];
+
+  /**
+   * @description Create a new instance of the option group
+   * @param  {string} label The options group label
+   * @param  {DialogSelectOption[]} options The options to be associated with this group
+   */
+  constructor(label: string, options: DialogSelectOption[]) {
+    Helpers.validateString(label, 'label', 75);
+    Helpers.validateArrayLength(options, 100, 'A group cannot have more than 100 options');
+    Helpers.validateOptions(options);
+
+    this.label = label;
+    this.options = options;
+  }
+}

--- a/src/FeatureElements/DialogText.ts
+++ b/src/FeatureElements/DialogText.ts
@@ -1,0 +1,9 @@
+import DialogElement from './DialogElement';
+import { DialogTextSubTypes } from './DialogTextElement';
+
+export default abstract class DialogText extends DialogElement {
+  public max_length?: number;
+  public min_length?: number;
+  public hint?: string;
+  public subtype?: DialogTextSubTypes;
+}

--- a/src/FeatureElements/DialogTextElement.ts
+++ b/src/FeatureElements/DialogTextElement.ts
@@ -1,0 +1,83 @@
+import { Helpers } from '../helpers';
+import { DialogElementType } from './DialogElement';
+import DialogText from './DialogText';
+
+export enum DialogTextSubTypes {
+  email = 'email',
+  number = 'number',
+  tel = 'tel',
+  url = 'url',
+}
+
+/** This class represents a Text field of a slack dialog.
+ *  For more info kindly visit https://api.slack.com/dialogs#text_elements
+ */
+export default class DialogTextElement extends DialogText {
+  /**
+   * @description Constructs a new instance of the DialogTextElement
+   * @param  {string} label The label of the field
+   * @param  {string} name The name of the field
+   */
+  constructor(label: string, name: string) {
+    super(label, name, DialogElementType.text);
+  }
+
+  /**
+   * @description Assign a max length to this field
+   * @param  {number} maxLength The maximum length of the string
+   * @returns DialogTextElement
+   */
+  public assignMaxLength(maxLength: number): DialogTextElement {
+    Helpers.validateNumber('maxLength', maxLength, 150, 0);
+
+    this.max_length = maxLength;
+    return this;
+  }
+
+  /**
+   * @description Assign a minimum length to this field
+   * @param  {number} minLength The minimum length of this field
+   * @returns DialogTextElement
+   */
+  public assignMinLength(minLength: number): DialogTextElement {
+    Helpers.validateNumber('minLength', minLength, 150, 1);
+
+    this.min_length = minLength;
+    return this;
+  }
+
+  /**
+   * @description Add a hint to the dialog field
+   * @param  {string} hint The fields hint
+   * @returns DialogTextElement
+   */
+  public addHint(hint: string): DialogTextElement {
+    Helpers.validateString(hint, 'hint', 150);
+
+    this.hint = hint;
+    return this;
+  }
+
+  /**
+   * @description Add a subtype to this field to offer some validation
+   * @param  {DialogTextSubTypes} type The type pf this text
+   * @returns DialogTextElement
+   */
+  public addTextSubType(type: DialogTextSubTypes): DialogTextElement {
+    this.subtype = type;
+
+    return this;
+  }
+
+  /**
+   * @description Add a default value to the text field
+   * @param  {string} value The default value
+   * @returns DialogTextElement
+   */
+  public setDefaultValue(value: string): DialogTextElement {
+    Helpers.validateString(value, 'value', 150);
+
+    this.value = value;
+    return this;
+  }
+}

--- a/src/FeatureElements/DialogTextareaElement.ts
+++ b/src/FeatureElements/DialogTextareaElement.ts
@@ -1,0 +1,77 @@
+import { Helpers } from '../helpers';
+import { DialogElementType } from './DialogElement';
+import DialogText from './DialogText';
+import { DialogTextSubTypes } from './DialogTextElement';
+
+/** This class represents a Textarea field of a slack dialog.
+ *  For more info kindly visit https://api.slack.com/dialogs#attributes_textarea_elements
+ */
+export default class DialogTextareaElement extends DialogText {
+  /**
+   * @description Constructs a new instance of the DialogTextElement
+   * @param  {string} label The label of the field
+   * @param  {string} name The name of the field
+   */
+  constructor(label: string, name: string) {
+    super(label, name, DialogElementType.textarea);
+  }
+
+  /**
+   * @description Assign a max length to this field
+   * @param  {number} maxLength The maximum length of the string
+   * @returns DialogTextareaElement
+   */
+  public assignMaxLength(maxLength: number): DialogTextareaElement {
+    Helpers.validateNumber('maxLength', maxLength, 3000, 0);
+
+    this.max_length = maxLength;
+    return this;
+  }
+
+  /**
+   * @description Assign a minimum length to this field
+   * @param  {number} minLength The minimum length of this field
+   * @returns DialogTextareaElement
+   */
+  public assignMinLength(minLength: number): DialogTextareaElement {
+    Helpers.validateNumber('minLength', minLength, 3000, 1);
+
+    this.min_length = minLength;
+    return this;
+  }
+
+  /**
+   * @description Add a hint to the dialog field
+   * @param  {string} hint The fields hint
+   * @returns DialogTextareaElement
+   */
+  public addHint(hint: string): DialogTextareaElement {
+    Helpers.validateString(hint, 'hint', 150);
+
+    this.hint = hint;
+    return this;
+  }
+
+  /**
+   * @description Add a subtype to this field to offer some validation
+   * @param  {DialogTextSubTypes} type The type of this text
+   * @returns DialogTextareaElement
+   */
+  public addTextSubType(type: DialogTextSubTypes): DialogTextareaElement {
+    this.subtype = type;
+
+    return this;
+  }
+
+  /**
+   * @description Add a default value to the text field
+   * @param  {string} value The default value
+   * @returns DialogTextareaElement
+   */
+  public setDefaultValue(value: string): DialogTextareaElement {
+    Helpers.validateString(value, 'value', 3000);
+
+    this.value = value;
+    return this;
+  }
+}

--- a/src/FeatureElements/__tests__/Dialog.spec.ts
+++ b/src/FeatureElements/__tests__/Dialog.spec.ts
@@ -1,0 +1,92 @@
+import Dialog from '../Dialog';
+import DialogTextElement from '../DialogTextElement';
+
+describe('Dialog', () => {
+  it('should create a new dialog', () => {
+    const dialog = new Dialog('Dialog Title', 'callback', [new DialogTextElement('label', 'name')]);
+
+    expect(dialog).toEqual({
+      callback_id: 'callback',
+      elements: [
+        {
+          label: 'label',
+          name: 'name',
+          type: 'text',
+        },
+      ],
+      title: 'Dialog Title',
+    });
+  });
+
+  it('should throw an error if no elements are assigned', done => {
+    try {
+      const dialog = new Dialog('Dialog Title', 'callback', []);
+    } catch (error) {
+      expect(error.message).toEqual('You need to add at least one element to the dialog');
+      done();
+    }
+  });
+
+  describe('addState', () => {
+    it('should add a state to the dialog', () => {
+      const dialog = new Dialog('Dialog Title', 'callback', [new DialogTextElement('label', 'name')]);
+
+      dialog.addState('dialog state');
+
+      expect(dialog).toEqual({
+        callback_id: 'callback',
+        elements: [
+          {
+            label: 'label',
+            name: 'name',
+            type: 'text',
+          },
+        ],
+        state: 'dialog state',
+        title: 'Dialog Title',
+      });
+    });
+  });
+
+  describe('changeSubmitLabel', () => {
+    it('should add a submit label', () => {
+      const dialog = new Dialog('Dialog Title', 'callback', [new DialogTextElement('label', 'name')]);
+
+      dialog.changeSubmitLabel('Read');
+
+      expect(dialog).toEqual({
+        callback_id: 'callback',
+        elements: [
+          {
+            label: 'label',
+            name: 'name',
+            type: 'text',
+          },
+        ],
+        submit_label: 'Read',
+        title: 'Dialog Title',
+      });
+    });
+  });
+
+  describe('notifyOnCancel', () => {
+    it('should add a submit label', () => {
+      const dialog = new Dialog('Dialog Title', 'callback', [new DialogTextElement('label', 'name')]);
+
+      dialog.notifyOnCancel();
+
+      expect(dialog).toEqual({
+        callback_id: 'callback',
+        elements: [
+          {
+            label: 'label',
+            name: 'name',
+            type: 'text',
+          },
+        ],
+        notify_on_cancel: true,
+        title: 'Dialog Title',
+      });
+    });
+  });
+});

--- a/src/FeatureElements/__tests__/DialogSelectElement.spec.ts
+++ b/src/FeatureElements/__tests__/DialogSelectElement.spec.ts
@@ -1,0 +1,226 @@
+import DialogSelectElement, { DialogSelectDataSource } from '../DialogSelectElement';
+import DialogSelectOption from '../DialogSelectOption';
+import Option from '../../CompositionObjects/Option';
+import DialogSelectOptionGroup from '../DialogSelectOptionGroup';
+
+describe('DialogSelectElement', () => {
+  it('should create a new select element', () => {
+    const selectMenu = new DialogSelectElement('Select an option', 'name');
+
+    expect(selectMenu).toEqual({
+      label: 'Select an option',
+      name: 'name',
+      type: 'select',
+    });
+  });
+
+  describe('changeDataSource', () => {
+    it('should change data source to external', () => {
+      const selectMenu = new DialogSelectElement('Select an option', 'name');
+
+      selectMenu.changeDataSource(DialogSelectDataSource.external);
+
+      expect(selectMenu).toEqual({
+        data_source: 'external',
+        label: 'Select an option',
+        name: 'name',
+        type: 'select',
+      });
+    });
+  });
+
+  describe('addMinQueryLength', () => {
+    it('should change data source to external', () => {
+      const selectMenu = new DialogSelectElement('Select an option', 'name');
+
+      selectMenu.changeDataSource(DialogSelectDataSource.external).addMinQueryLength(3);
+
+      expect(selectMenu).toEqual({
+        data_source: 'external',
+        label: 'Select an option',
+        min_query_length: 3,
+        name: 'name',
+        type: 'select',
+      });
+    });
+
+    it('should throw an error if the data source has not been set to external', done => {
+      try {
+        const selectMenu = new DialogSelectElement('Select an option', 'name');
+
+        selectMenu.addMinQueryLength(3);
+
+        expect(selectMenu).toEqual({
+          data_source: 'external',
+          label: 'Select an option',
+          min_query_length: 3,
+          name: 'name',
+          type: 'select',
+        });
+      } catch (error) {
+        expect(error.message).toEqual('Only external data sources require a min query length');
+        done();
+      }
+    });
+  });
+
+  describe('addSelectedOption', () => {
+    it('should add a default select option', () => {
+      const selectMenu = new DialogSelectElement('Select an option', 'name');
+
+      selectMenu.addSelectedOption(new DialogSelectOption('label', 'value'));
+
+      expect(selectMenu).toEqual({
+        label: 'Select an option',
+        name: 'name',
+        selected_options: {
+          label: 'label',
+          value: 'value',
+        },
+        type: 'select',
+      });
+    });
+  });
+
+  describe('addOptions', () => {
+    it('should add an array of options to the menu', () => {
+      const selectMenu = new DialogSelectElement('Select an option', 'name');
+
+      selectMenu.addOptions([
+        new DialogSelectOption('option 1', 'value 1'),
+        new DialogSelectOption('option 2', 'value 2'),
+      ]);
+
+      expect(selectMenu).toEqual({
+        label: 'Select an option',
+        name: 'name',
+        options: [
+          {
+            label: 'option 1',
+            value: 'value 1',
+          },
+          {
+            label: 'option 2',
+            value: 'value 2',
+          },
+        ],
+        type: 'select',
+      });
+    });
+
+    it('should add more options to the menu', () => {
+      const selectMenu = new DialogSelectElement('Select an option', 'name');
+
+      selectMenu
+        .addOptions([new DialogSelectOption('option 1', 'value 1'), new DialogSelectOption('option 2', 'value 2')])
+        .addOptions([new DialogSelectOption('option 3', 'value 3')]);
+
+      expect(selectMenu).toEqual({
+        label: 'Select an option',
+        name: 'name',
+        options: [
+          {
+            label: 'option 1',
+            value: 'value 1',
+          },
+          {
+            label: 'option 2',
+            value: 'value 2',
+          },
+          {
+            label: 'option 3',
+            value: 'value 3',
+          },
+        ],
+        type: 'select',
+      });
+    });
+
+    it('should throw an error if option_group is already added', done => {
+      try {
+        const selectMenu = new DialogSelectElement('Select an option', 'name');
+
+        selectMenu
+          .addOptionsGroup([new DialogSelectOptionGroup('label', [new DialogSelectOption('option 1', 'value 1')])])
+          .addOptions([new DialogSelectOption('option 1', 'value 1'), new DialogSelectOption('option 2', 'value 2')]);
+      } catch (error) {
+        expect(error.message).toEqual('Cannot have options and option_groups in the same select menu');
+        done();
+      }
+    });
+  });
+
+  describe('addOptionsGroup', () => {
+    it('should add options group to the menu', () => {
+      const selectMenu = new DialogSelectElement('label', 'name');
+
+      selectMenu.addOptionsGroup([
+        new DialogSelectOptionGroup('label', [new DialogSelectOption('option 1', 'value 1')]),
+      ]);
+
+      expect(selectMenu).toEqual({
+        label: 'label',
+        name: 'name',
+        option_groups: [
+          {
+            label: 'label',
+            options: [
+              {
+                label: 'option 1',
+                value: 'value 1',
+              },
+            ],
+          },
+        ],
+        type: 'select',
+      });
+    });
+
+    it('should add more options group to the menu', () => {
+      const selectMenu = new DialogSelectElement('label', 'name');
+
+      selectMenu
+        .addOptionsGroup([new DialogSelectOptionGroup('label', [new DialogSelectOption('option 1', 'value 1')])])
+        .addOptionsGroup([new DialogSelectOptionGroup('label', [new DialogSelectOption('option 2', 'value 2')])]);
+
+      expect(selectMenu).toEqual({
+        label: 'label',
+        name: 'name',
+        option_groups: [
+          {
+            label: 'label',
+            options: [
+              {
+                label: 'option 1',
+                value: 'value 1',
+              },
+            ],
+          },
+          {
+            label: 'label',
+            options: [
+              {
+                label: 'option 2',
+                value: 'value 2',
+              },
+            ],
+          },
+        ],
+        type: 'select',
+      });
+    });
+
+    it('should throw an error if options have already been assigned', done => {
+      try {
+        const selectMenu = new DialogSelectElement('label', 'name');
+
+        selectMenu
+          .addOptions([new DialogSelectOption('option 3', 'value 3')])
+          .addOptionsGroup([new DialogSelectOptionGroup('label', [new DialogSelectOption('option 1', 'value 1')])]);
+      } catch (error) {
+        expect(error.message).toEqual('Cannot have options and option_groups in the same select menu');
+        done();
+      }
+    });
+  });
+});

--- a/src/FeatureElements/__tests__/DialogSelectOption.spec.ts
+++ b/src/FeatureElements/__tests__/DialogSelectOption.spec.ts
@@ -1,0 +1,12 @@
+import DialogSelectOption from '../DialogSelectOption';
+
+describe('DialogSelectOption', () => {
+  it('should create a new option object', () => {
+    const opt = new DialogSelectOption('option 1', 'one');
+
+    expect(opt).toEqual({
+      label: 'option 1',
+      value: 'one',
+    });
+  });
+});

--- a/src/FeatureElements/__tests__/DialogSelectOptionGroup.spec.ts
+++ b/src/FeatureElements/__tests__/DialogSelectOptionGroup.spec.ts
@@ -1,0 +1,18 @@
+import DialogSelectOption from '../DialogSelectOption';
+import DialogSelectOptionGroup from '../DialogSelectOptionGroup';
+
+describe('DialogSelectOptionGroup', () => {
+  it('should create a new dialog option group', () => {
+    const optGroup = new DialogSelectOptionGroup('label', [new DialogSelectOption('option label', 'option value')]);
+
+    expect(optGroup).toEqual({
+      label: 'label',
+      options: [
+        {
+          label: 'option label',
+          value: 'option value',
+        },
+      ],
+    });
+  });
+});

--- a/src/FeatureElements/__tests__/DialogTextElement.spec.ts
+++ b/src/FeatureElements/__tests__/DialogTextElement.spec.ts
@@ -1,0 +1,118 @@
+import DialogTextElement, { DialogTextSubTypes } from '../DialogTextElement';
+
+describe('TextDialogElement', () => {
+  it('should create a dialog text element', () => {
+    const text = new DialogTextElement('Name', 'name');
+
+    expect(text).toEqual({
+      label: 'Name',
+      name: 'name',
+      type: 'text',
+    });
+  });
+
+  describe('assignMaxLength', () => {
+    it('should add a max length to the string', () => {
+      const text = new DialogTextElement('Name', 'name');
+
+      text.assignMaxLength(50);
+
+      expect(text).toEqual({
+        label: 'Name',
+        max_length: 50,
+        name: 'name',
+        type: 'text',
+      });
+    });
+  });
+
+  describe('assignMinLength', () => {
+    it('should add a min length to the string', () => {
+      const text = new DialogTextElement('Name', 'name');
+
+      text.assignMinLength(50);
+
+      expect(text).toEqual({
+        label: 'Name',
+        min_length: 50,
+        name: 'name',
+        type: 'text',
+      });
+    });
+  });
+
+  describe('addHint', () => {
+    it('should add a hint text', () => {
+      const text = new DialogTextElement('Name', 'name');
+
+      text.addHint('A sample hint');
+
+      expect(text).toEqual({
+        hint: 'A sample hint',
+        label: 'Name',
+        name: 'name',
+        type: 'text',
+      });
+    });
+  });
+
+  describe('addTextSubType', () => {
+    it('should add a subtype', () => {
+      const email = new DialogTextElement('Email', 'email');
+
+      email.addTextSubType(DialogTextSubTypes.email);
+
+      expect(email).toEqual({
+        label: 'Email',
+        name: 'email',
+        subtype: 'email',
+        type: 'text',
+      });
+    });
+  });
+
+  describe('setDefaultValue', () => {
+    it('should add a default value', () => {
+      const email = new DialogTextElement('Email', 'email');
+
+      email.setDefaultValue('example@email.com');
+
+      expect(email).toEqual({
+        label: 'Email',
+        name: 'email',
+        type: 'text',
+        value: 'example@email.com',
+      });
+    });
+  });
+
+  describe('addPlaceholder', () => {
+    it('should add a placeholder', () => {
+      const email = new DialogTextElement('Email', 'email');
+
+      email.addPlaceholder('Your email...');
+
+      expect(email).toEqual({
+        label: 'Email',
+        name: 'email',
+        placeholder: 'Your email...',
+        type: 'text',
+      });
+    });
+  });
+
+  describe('makeFieldOptional', () => {
+    it('should make the field optional', () => {
+      const email = new DialogTextElement('Email', 'email');
+
+      email.makeFieldOptional();
+
+      expect(email).toEqual({
+        label: 'Email',
+        name: 'email',
+        optional: true,
+        type: 'text',
+      });
+    });
+  });
+});

--- a/src/FeatureElements/__tests__/DialogTextareaElement.spec.ts
+++ b/src/FeatureElements/__tests__/DialogTextareaElement.spec.ts
@@ -1,0 +1,89 @@
+import DialogTextareaElement from '../DialogTextareaElement';
+import { DialogTextSubTypes } from '../DialogTextElement';
+
+describe('DialogTextareaElement', () => {
+  it('should create a dialog textarea', () => {
+    const textarea = new DialogTextareaElement('Reason', 'reason');
+
+    expect(textarea).toEqual({
+      label: 'Reason',
+      name: 'reason',
+      type: 'textarea',
+    });
+  });
+
+  describe('assignMaxLength', () => {
+    it('should add a max length to the string', () => {
+      const textarea = new DialogTextareaElement('Reason', 'reason');
+
+      textarea.assignMaxLength(50);
+
+      expect(textarea).toEqual({
+        label: 'Reason',
+        max_length: 50,
+        name: 'reason',
+        type: 'textarea',
+      });
+    });
+  });
+
+  describe('assignMinLength', () => {
+    it('should add a min length to the string', () => {
+      const textarea = new DialogTextareaElement('Reason', 'reason');
+
+      textarea.assignMinLength(50);
+
+      expect(textarea).toEqual({
+        label: 'Reason',
+        min_length: 50,
+        name: 'reason',
+        type: 'textarea',
+      });
+    });
+  });
+
+  describe('addHint', () => {
+    it('should add a hint text', () => {
+      const textarea = new DialogTextareaElement('Reason', 'reason');
+
+      textarea.addHint('A sample hint');
+
+      expect(textarea).toEqual({
+        hint: 'A sample hint',
+        label: 'Reason',
+        name: 'reason',
+        type: 'textarea',
+      });
+    });
+  });
+
+  describe('addTextSubType', () => {
+    it('should add a subtype', () => {
+      const textarea = new DialogTextareaElement('Reason', 'reason');
+
+      textarea.addTextSubType(DialogTextSubTypes.number);
+
+      expect(textarea).toEqual({
+        label: 'Reason',
+        name: 'reason',
+        subtype: 'number',
+        type: 'textarea',
+      });
+    });
+  });
+
+  describe('setDefaultValue', () => {
+    it('should add a default value', () => {
+      const textarea = new DialogTextareaElement('Reason', 'reason');
+
+      textarea.setDefaultValue('example@email.com');
+
+      expect(textarea).toEqual({
+        label: 'Reason',
+        name: 'reason',
+        type: 'textarea',
+        value: 'example@email.com',
+      });
+    });
+  });
+});

--- a/src/helpers/__tests__/index.spec.ts
+++ b/src/helpers/__tests__/index.spec.ts
@@ -11,4 +11,26 @@ describe('Helpers', () => {
       }
     });
   });
+
+  describe('validateNumber()', () => {
+    it('should throw an error if number is beyond', done => {
+      try {
+        Helpers.validateNumber('param', 10, 5, 0);
+      } catch (error) {
+        expect(error.message).toEqual('param must be a positive integer less than 5 and greater than 0');
+        done();
+      }
+    });
+  });
+
+  describe('validateNumber()', () => {
+    it('should throw an error if number is invalid', done => {
+      try {
+        Helpers.validateNumber('param', 'ten', 5, 0);
+      } catch (error) {
+        expect(error.message).toEqual('param must be a positive integer');
+        done();
+      }
+    });
+  });
 });

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -1,6 +1,22 @@
 import Option from '../CompositionObjects/Option';
+import DialogSelectOption from '../FeatureElements/DialogSelectOption';
 
 export class Helpers {
+  /**
+   * @description Ensure that number is valid
+   * @param  {string} param The parameter name
+   * @param  {number} num The number to be validated
+   * @param  {number} max The maximum number expected
+   */
+  public static validateNumber(param: string, num: number | string, max: number, min: number) {
+    if (!/^\d+$/.test(num.toString())) {
+      throw new Error(`${param} must be a positive integer`);
+    }
+    if (num <= min || num > max) {
+      throw new Error(`${param} must be a positive integer less than ${max} and greater than ${min}`);
+    }
+  }
+
   /**
    * @description Validate a strings character length
    * @param  {string} param The parameter to be validated
@@ -18,7 +34,7 @@ export class Helpers {
    * @param  {Option[]} options
    * @returns void
    */
-  public static validateOptions(options: Option[]): void {
+  public static validateOptions(options: Option[] | DialogSelectOption[]): void {
     const optionsValues: { [k: string]: boolean } = {};
 
     for (const option of options) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,12 @@ import ConfirmationDialog from './CompositionObjects/ConfirmationDialog';
 import Option from './CompositionObjects/Option';
 import OptionGroup from './CompositionObjects/OptionGroup';
 import Text, { TextType } from './CompositionObjects/Text';
+import Dialog from './FeatureElements/Dialog';
+import DialogSelectElement from './FeatureElements/DialogSelectElement';
+import DialogSelectOption from './FeatureElements/DialogSelectOption';
+import DialogSelectOptionGroup from './FeatureElements/DialogSelectOptionGroup';
+import DialogTextareaElement from './FeatureElements/DialogTextareaElement';
+import DialogTextElement from './FeatureElements/DialogTextElement';
 import InteractiveMessage from './InteractiveMessage';
 
 export {
@@ -33,6 +39,12 @@ export {
   Context,
   ConversationSelectElement,
   DatePickerElement,
+  Dialog,
+  DialogSelectElement,
+  DialogSelectOption,
+  DialogSelectOptionGroup,
+  DialogTextareaElement,
+  DialogTextElement,
   Divider,
   ExternalSelectElement,
   Image,


### PR DESCRIPTION
# Add Slack Dialog

## What does this PR do

This PR adds the slack dialog and its required elements to this library

## Background context

The slack dialogues are very important for the sake of collecting information from the user.

## Task completed (detailed list of changes/additions)

- [x] add slack dialog element
- [x] add dialog text element
- [x] add dialog textarea element
- [x] add dialog select element
- [x] add select options and group element
